### PR TITLE
Auto-update task end date when start date changes

### DIFF
--- a/js/jpcrm-admin-tasks.js
+++ b/js/jpcrm-admin-tasks.js
@@ -17,6 +17,8 @@ function jpcrm_update_task_status( task_id, new_status ) {
 		return;
 	}
 
+	const buttons = document.querySelectorAll( '#mark-complete-task button' );
+
 	window.jpcrm_task_ajax_blocker = true;
 	buttons.forEach( b => b.classList.add( 'disabled', 'loading' ) );
 
@@ -54,21 +56,77 @@ function jpcrm_update_task_status( task_id, new_status ) {
 		} );
 }
 
-const buttons = document.querySelectorAll( '#mark-complete-task button' );
-buttons.forEach( el =>
-	el.addEventListener( 'click', function ( e ) {
-		e.preventDefault();
-		const task_id = el.closest( '[id^="task-"]' ).id.slice( 5 );
-		const new_status = -document.getElementById( 'zbs-task-complete' ).value;
-		jpcrm_update_task_status( task_id, new_status );
-	} )
-);
+/**
+ * Keep the task end date in sync with the task start date.
+ *
+ * If the user changes the start date to a date after the current end date,
+ * update the end date to match the start date.
+ *
+ * This uses event delegation so it also works when the task form is added
+ * to the page after the initial page load.
+ *
+ * @param {Event} event Input/change event.
+ */
+function jpcrm_sync_task_end_date_with_start_date( event ) {
+	if (
+		! event.target ||
+		! event.target.matches( 'input[name="jpcrm_start_datepart"]' )
+	) {
+		return;
+	}
+
+	const startDateInput = event.target;
+	const taskWrapper =
+		startDateInput.closest( '.jpcrm-task-editor-wrap' ) ||
+		startDateInput.closest( 'table' ) ||
+		document;
+
+	const endDateInput =
+		taskWrapper.querySelector( 'input[name="jpcrm_end_datepart"]' ) ||
+		document.querySelector( 'input[name="jpcrm_end_datepart"]' );
+
+	if ( ! endDateInput || ! startDateInput.value ) {
+		return;
+	}
+
+	if ( ! endDateInput.value || endDateInput.value < startDateInput.value ) {
+		endDateInput.value = startDateInput.value;
+		endDateInput.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		endDateInput.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+	}
+}
+
+document.addEventListener( 'input', jpcrm_sync_task_end_date_with_start_date );
+document.addEventListener( 'change', jpcrm_sync_task_end_date_with_start_date );
+
+document.addEventListener( 'click', function ( e ) {
+	const button = e.target.closest( '#mark-complete-task button' );
+
+	if ( ! button ) {
+		return;
+	}
+
+	e.preventDefault();
+
+	const taskWrapper = button.closest( '[id^="task-"]' );
+	const completeInput = document.getElementById( 'zbs-task-complete' );
+
+	if ( ! taskWrapper || ! completeInput ) {
+		return;
+	}
+
+	const task_id = taskWrapper.id.slice( 5 );
+	const new_status = -completeInput.value;
+
+	jpcrm_update_task_status( task_id, new_status );
+} );
 
 document.addEventListener( 'DOMContentLoaded', function () {
 	const calendarEl = document.getElementById( 'calendar' );
 	if ( ! calendarEl ) {
 		return;
 	}
+
 	const calendar = new FullCalendar.Calendar( calendarEl, {
 		locale: jpcrm_fullcalendar_data.locale,
 		headerToolbar: {
@@ -89,21 +147,30 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			const completeHTML = eventProps.complete === 1 ? '<i class="fa fa-check"></i></span>' : '';
 			const decodedTitle = args.event.title ? jpcrm.decodeHTMLEntities( args.event.title ) : '';
 			let eventText = jpcrm.esc_html( decodedTitle );
+
 			if ( args.view.type !== 'listMonth' ) {
 				// listMonth has the timeText displayed already.
 				eventText = args.timeText + ' ' + eventText;
 			}
+
 			let html = avatarHTML + completeHTML + eventText;
 			html =
-				'<div class="event_html" title="' + jpcrm.esc_attr( decodedTitle ) + '">' + html + '</div>';
+				'<div class="event_html" title="' +
+				jpcrm.esc_attr( decodedTitle ) +
+				'">' +
+				html +
+				'</div>';
+
 			if ( args.view.type === 'listMonth' ) {
 				// All the other views add the link automatically, but not this one.
 				html = '<a href="' + jpcrm.esc_attr( args.event._def.url ) + '">' + html + '</a>';
 			}
+
 			return {
 				html: html,
 			};
 		},
 	} );
+
 	calendar.render();
 } );


### PR DESCRIPTION
## Summary

Fixes #1

When creating or editing a task, changing the start date to a date after the current end date did not update the end date in the UI. This meant users had to manually adjust the end date after moving the start date forward.

This PR updates the task date handling so that when the start date is changed, the end date is automatically moved to the same date if it is empty or earlier than the selected start date.

## Testing Instructions

1. Go to **Jetpack CRM → Companies** → Open any company → **Tasks** → **Add Task**.
2. Set the end date to an earlier date than the start date you are about to choose.
3. Change the start date to a later date.
4. Confirm the end date automatically updates to match the start date.
5. Confirm the end date is not overwritten when it is already after the start date.

## Changes

- Added event handling for the task start date field.
- Automatically updates the task end date when it is empty or earlier than the start date.