### PR TITLE
CRM: Align admin footer with the unified Jetpack footer

### DIFF
--- a/admin/settings/general.page.php
+++ b/admin/settings/general.page.php
@@ -632,7 +632,7 @@ if ( ! $confirmAct ) {
 			<tr>
 				<td class="wfieldname">
 					<label for="jpcrm_showpoweredby_admin"><?php esc_html_e( 'Show admin credits', 'zero-bs-crm' ); ?>:</label><br />
-					<?php esc_html_e( 'Show "Powered by Jetpack CRM" footers on backend admin pages.', 'zero-bs-crm' ); ?>
+					<?php esc_html_e( 'Show the Jetpack and Automattic logos in the footer of backend admin pages.', 'zero-bs-crm' ); ?>
 				</td>
 				<td style="width:540px">
 					<input type="checkbox" class="winput form-control" name="jpcrm_showpoweredby_admin" id="jpcrm_showpoweredby_admin" value="1"<?php echo isset( $settings['showpoweredby_admin'] ) && $settings['showpoweredby_admin'] === 0 ? '' : ' checked="checked"'; ?> />

--- a/includes/ZeroBSCRM.AdminStyling.php
+++ b/includes/ZeroBSCRM.AdminStyling.php
@@ -182,7 +182,7 @@ function zeroBSCRM_improvedPostMsgsTransactions( $messages ) {
 	WordPress Footer Msg
 	====================================================== */
 
-// } Footer Text
+// } Footer Text (left) - Jetpack logo + wordmark, matching the unified Jetpack admin footer
 function jpcrm_footer_credit_thanks( $content ) {
 
 	// return original text if not on a CRM page
@@ -194,7 +194,8 @@ function jpcrm_footer_credit_thanks( $content ) {
 	global $zbs;
 	$showpoweredby_admin = $zbs->settings->get( 'showpoweredby_admin' ) === 1 ? true : false;
 	if ( $showpoweredby_admin ) {
-		return '<span id="footer-thankyou">' . sprintf( __( 'Thank you for using <a href="%s">Jetpack CRM</a>.', 'zero-bs-crm' ), $zbs->urls['home'] ) . '</span>';
+		$jetpack_logo = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="16" height="16" aria-hidden="true" focusable="false"><path fill="#069e08" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"/></svg>';
+		return '<span class="jetpack-footer__logo">' . $jetpack_logo . '<span class="jetpack-footer__logo-text">Jetpack</span></span>';
 	}
 	##/WLREMOVE
 
@@ -203,6 +204,7 @@ function jpcrm_footer_credit_thanks( $content ) {
 }
 add_filter( 'admin_footer_text', 'jpcrm_footer_credit_thanks' );
 
+// } Footer Text (right) - Automattic "by line" logo, matching the unified Jetpack admin footer
 function jpcrm_footer_credit_version( $content ) {
 
 	// return original text if not on a CRM page
@@ -214,7 +216,9 @@ function jpcrm_footer_credit_version( $content ) {
 	global $zbs;
 	$showpoweredby_admin = $zbs->settings->get( 'showpoweredby_admin' ) === 1 ? true : false;
 	if ( $showpoweredby_admin ) {
-		return sprintf( 'Jetpack CRM v%s', $zbs::VERSION );
+		$byline_title = esc_attr__( 'An Automattic Airline', 'zero-bs-crm' );
+		$byline_svg   = '<svg role="img" x="0" y="0" viewBox="0 0 935 38.2" height="8" aria-hidden="true" focusable="false" class="jp-automattic-byline-logo"><path d="M317.1 38.2c-12.6 0-20.7-9.1-20.7-18.5v-1.2c0-9.6 8.2-18.5 20.7-18.5 12.6 0 20.8 8.9 20.8 18.5v1.2C337.9 29.1 329.7 38.2 317.1 38.2zM331.2 18.6c0-6.9-5-13-14.1-13s-14 6.1-14 13v0.9c0 6.9 5 13.1 14 13.1s14.1-6.2 14.1-13.1V18.6zM175 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7L157 1.3h5.5L182 36.8H175zM159.7 8.2L152 23.1h15.7L159.7 8.2zM212.4 38.2c-12.7 0-18.7-6.9-18.7-16.2V1.3h6.6v20.9c0 6.6 4.3 10.5 12.5 10.5 8.4 0 11.9-3.9 11.9-10.5V1.3h6.7V22C231.4 30.8 225.8 38.2 212.4 38.2zM268.6 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H268.6zM397.3 36.8V8.7l-1.8 3.1 -14.9 25h-3.3l-14.7-25 -1.8-3.1v28.1h-6.5V1.3h9.2l14 24.4 1.7 3 1.7-3 13.9-24.4h9.1v35.5H397.3zM454.4 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7l19.2-35.5h5.5l19.5 35.5H454.4zM439.1 8.2l-7.7 14.9h15.7L439.1 8.2zM488.4 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H488.4zM537.3 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H537.3zM569.3 36.8V4.6c2.7 0 3.7-1.4 3.7-3.4h2.8v35.5L569.3 36.8 569.3 36.8zM628 11.3c-3.2-2.9-7.9-5.7-14.2-5.7 -9.5 0-14.8 6.5-14.8 13.3v0.7c0 6.7 5.4 13 15.3 13 5.9 0 10.8-2.8 13.9-5.7l4 4.2c-3.9 3.8-10.5 7.1-18.3 7.1 -13.4 0-21.6-8.7-21.6-18.3v-1.2c0-9.6 8.9-18.7 21.9-18.7 7.5 0 14.3 3.1 18 7.1L628 11.3zM321.5 12.4c1.2 0.8 1.5 2.4 0.8 3.6l-6.1 9.4c-0.8 1.2-2.4 1.6-3.6 0.8l0 0c-1.2-0.8-1.5-2.4-0.8-3.6l6.1-9.4C318.7 11.9 320.3 11.6 321.5 12.4L321.5 12.4z"/><path d="M37.5 36.7l-4.7-8.9H11.7l-4.6 8.9H0L19.4 0.8H25l19.7 35.9H37.5zM22 7.8l-7.8 15.1h15.9L22 7.8zM82.8 36.7l-23.3-24 -2.3-2.5v26.6h-6.7v-36H57l22.6 24 2.3 2.6V0.8h6.7v35.9H82.8z"/><path d="M719.9 37l-4.8-8.9H694l-4.6 8.9h-7.1l19.5-36h5.6l19.8 36H719.9zM704.4 8l-7.8 15.1h15.9L704.4 8zM733 37V1h6.8v36H733zM781 37c-1.8 0-2.6-2.5-2.9-5.8l-0.2-3.7c-0.2-3.6-1.7-5.1-8.4-5.1h-12.8V37H750V1h19.6c10.8 0 15.7 4.3 15.7 9.9 0 3.9-2 7.7-9 9 7 0.5 8.5 3.7 8.6 7.9l0.1 3c0.1 2.5 0.5 4.3 2.2 6.1V37H781zM778.5 11.8c0-2.6-2.1-5.1-7.9-5.1h-13.8v10.8h14.4c5 0 7.3-2.4 7.3-5.2V11.8zM794.8 37V1h6.8v30.4h28.2V37H794.8zM836.7 37V1h6.8v36H836.7zM886.2 37l-23.4-24.1 -2.3-2.5V37h-6.8V1h6.5l22.7 24.1 2.3 2.6V1h6.8v36H886.2zM902.3 37V1H935v5.6h-26v9.2h20v5.5h-20v10.1h26V37H902.3z"/></svg>';
+		return '<a class="jetpack-footer__a8c" href="https://jetpack.com/redirect/?source=a8c-about" target="_blank" rel="noopener noreferrer" aria-label="' . $byline_title . '">' . $byline_svg . '</a>';
 	}
 	##/WLREMOVE
 

--- a/sass/emerald/_jpcrm_footer.scss
+++ b/sass/emerald/_jpcrm_footer.scss
@@ -1,0 +1,76 @@
+/*
+ * Jetpack CRM admin footer
+ *
+ * Restyles WordPress' #wpfooter on CRM admin pages to match the unified Jetpack
+ * admin-page footer: Jetpack logo + wordmark on the left, Automattic "by line"
+ * on the right. The footer contents are injected via the `admin_footer_text`
+ * (left) and `update_footer` (right) filters in ZeroBSCRM.AdminStyling.php.
+ *
+ * Note: WPDS custom properties (--wpds-*) are referenced with hardcoded
+ * fallbacks so this renders correctly whether or not the design tokens are
+ * present, mirroring the approach used by the top menu (_jpcrm_top_menu.scss).
+ */
+
+body.jpcrm-admin {
+
+	// Only restyle the footer when our branded footer content is present. When the
+	// "powered by" setting is off (or under white label) #wpfooter is left empty and
+	// keeps its default WordPress appearance.
+	#wpfooter:has( .jetpack-footer__logo ) {
+		align-items: center;
+		background-color: var(--wpds-color-background-surface-neutral, #fcfcfc);
+		border-top: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak, #e0e0e0);
+		box-sizing: border-box;
+		display: flex;
+		flex-wrap: wrap;
+		font-size: var(--wpds-typography-font-size-md, 13px);
+		gap: 8px 24px;
+		padding: var(--wpds-dimension-padding-xl, 16px) var(--wpds-dimension-padding-2xl, 24px);
+
+		// Undo WordPress' default float-based left/right layout; flex handles it.
+		p {
+			float: none;
+			line-height: 1;
+			margin: 0;
+			padding: 0;
+		}
+
+		// Push the Automattic by line to the far right.
+		#footer-upgrade {
+			margin-inline-start: auto;
+		}
+
+		.clear {
+			display: none;
+		}
+	}
+
+	// Left: Jetpack logo + wordmark.
+	.jetpack-footer__logo {
+		align-items: center;
+		display: inline-flex;
+		gap: 8px;
+
+		svg {
+			display: block;
+			flex-shrink: 0;
+		}
+	}
+
+	.jetpack-footer__logo-text {
+		color: var(--wpds-color-foreground-neutral-strong, #1e1e1e);
+		font-size: var(--wpds-typography-font-size-md, 13px);
+		line-height: 1;
+	}
+
+	// Right: Automattic "by line".
+	a.jetpack-footer__a8c {
+		align-items: center;
+		display: inline-flex;
+
+		svg {
+			display: block;
+			fill: var(--wpds-color-foreground-interactive-neutral-weak, #646970);
+		}
+	}
+}

--- a/sass/emerald/_jpcrm_footer.scss
+++ b/sass/emerald/_jpcrm_footer.scss
@@ -5,14 +5,14 @@ body.jpcrm-admin {
 	// keeps its default WordPress appearance.
 	#wpfooter:has( .jetpack-footer__logo ) {
 		align-items: center;
-		background-color: var(--wpds-color-background-surface-neutral, #fcfcfc);
-		border-top: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak, #e0e0e0);
+		background-color: var(--wpds-color-bg-surface-neutral, var(--wpds-color-background-surface-neutral, #fcfcfc));
+		border-top: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak, #e4e4e4);
 		box-sizing: border-box;
 		display: flex;
 		flex-wrap: wrap;
 		font-size: var(--wpds-typography-font-size-md, 13px);
 		gap: var(--wpds-dimension-gap-xl, 24px);
-		padding: var(--wpds-dimension-padding-xl, 16px) var(--wpds-dimension-padding-2xl, 24px);
+		padding: var(--wpds-dimension-padding-xl, 20px) var(--wpds-dimension-padding-2xl, 24px);
 
 		// Wide footer: single row, Automattic by line pushed to the far right.
 		#footer-upgrade {
@@ -27,9 +27,11 @@ body.jpcrm-admin {
 		}
 	}
 
-	// On mobile WordPress moves the admin menu off-canvas, but on CRM's non-fluid
-	// pages it can leave the desktop left margin on #wpfooter, indenting it. Drop
-	// it so the footer sits flush with the screen edge.
+	// Below 782px WordPress core hides #wpfooter (common.css), but the base rule
+	// above keeps it shown — specificity (1,2,1) vs core's (1,0,0), and no media
+	// query — which is why these mobile rules are reachable at all. Core's
+	// `.auto-fold #wpfooter` also leaves a 36px icon-menu margin here (admin-menu.css,
+	// @media max-width: 960px); drop it so the footer sits flush with the screen edge.
 	@media ( max-width: 782px ) {
 
 		#wpfooter:has( .jetpack-footer__logo ) {
@@ -68,7 +70,7 @@ body.jpcrm-admin {
 	}
 
 	.jetpack-footer__logo-text {
-		color: var(--wpds-color-foreground-neutral-strong, #1e1e1e);
+		color: var(--wpds-color-fg-content-neutral, var(--wpds-color-foreground-content-neutral, #1e1e1e));
 		font-size: var(--wpds-typography-font-size-md, 13px);
 		line-height: 1;
 	}
@@ -80,7 +82,7 @@ body.jpcrm-admin {
 
 		svg {
 			display: block;
-			fill: var(--wpds-color-foreground-interactive-neutral-weak, #646970);
+			fill: var(--wpds-color-fg-interactive-neutral-weak, var(--wpds-color-foreground-interactive-neutral-weak, #707070));
 		}
 	}
 }

--- a/sass/emerald/_jpcrm_footer.scss
+++ b/sass/emerald/_jpcrm_footer.scss
@@ -1,16 +1,3 @@
-/*
- * Jetpack CRM admin footer
- *
- * Restyles WordPress' #wpfooter on CRM admin pages to match the unified Jetpack
- * admin-page footer: Jetpack logo + wordmark on the left, Automattic "by line"
- * on the right. The footer contents are injected via the `admin_footer_text`
- * (left) and `update_footer` (right) filters in ZeroBSCRM.AdminStyling.php.
- *
- * Note: WPDS custom properties (--wpds-*) are referenced with hardcoded
- * fallbacks so this renders correctly whether or not the design tokens are
- * present, mirroring the approach used by the top menu (_jpcrm_top_menu.scss).
- */
-
 body.jpcrm-admin {
 
 	// Only restyle the footer when our branded footer content is present. When the
@@ -27,19 +14,14 @@ body.jpcrm-admin {
 		gap: var(--wpds-dimension-gap-xl, 24px);
 		padding: var(--wpds-dimension-padding-xl, 16px) var(--wpds-dimension-padding-2xl, 24px);
 
-		// Undo WordPress' default float-based left/right layout; flex handles it.
-		p {
-			float: none;
-			line-height: 1;
-			margin: 0;
-			padding: 0;
-		}
-
 		// Wide footer: single row, Automattic by line pushed to the far right.
 		#footer-upgrade {
 			margin-inline-start: auto;
 		}
 
+		// WordPress core outputs an empty <div class="clear"> inside #wpfooter;
+		// as a flex item it would add a trailing gap that pushes the by line off
+		// the right edge, so drop it out of the layout.
 		.clear {
 			display: none;
 		}

--- a/sass/emerald/_jpcrm_footer.scss
+++ b/sass/emerald/_jpcrm_footer.scss
@@ -24,7 +24,7 @@ body.jpcrm-admin {
 		display: flex;
 		flex-wrap: wrap;
 		font-size: var(--wpds-typography-font-size-md, 13px);
-		gap: 8px 24px;
+		gap: var(--wpds-dimension-gap-xl, 24px);
 		padding: var(--wpds-dimension-padding-xl, 16px) var(--wpds-dimension-padding-2xl, 24px);
 
 		// Undo WordPress' default float-based left/right layout; flex handles it.
@@ -35,13 +35,41 @@ body.jpcrm-admin {
 			padding: 0;
 		}
 
-		// Push the Automattic by line to the far right.
+		// Wide footer: single row, Automattic by line pushed to the far right.
 		#footer-upgrade {
 			margin-inline-start: auto;
 		}
 
 		.clear {
 			display: none;
+		}
+	}
+
+	// On mobile WordPress moves the admin menu off-canvas, but on CRM's non-fluid
+	// pages it can leave the desktop left margin on #wpfooter, indenting it. Drop
+	// it so the footer sits flush with the screen edge.
+	@media ( max-width: 782px ) {
+
+		#wpfooter:has( .jetpack-footer__logo ) {
+			margin: 0;
+		}
+	}
+
+	// Phones: stack the logo and the Automattic by line onto their own left-aligned
+	// rows, matching the unified Jetpack footer. Unlike that footer we have no
+	// middle nav links to force the wrap, so we stack explicitly.
+	@media ( max-width: 480px ) {
+
+		#wpfooter:has( .jetpack-footer__logo ) {
+
+			#footer-left,
+			#footer-upgrade {
+				flex-basis: 100%;
+			}
+
+			#footer-upgrade {
+				margin-inline-start: 0;
+			}
 		}
 	}
 

--- a/sass/jpcrm-emerald.scss
+++ b/sass/jpcrm-emerald.scss
@@ -8,6 +8,9 @@
 /* top menu */
 @use "emerald/jpcrm_top_menu";
 
+/* footer */
+@use "emerald/jpcrm_footer";
+
 /* components */
 @use "emerald/buttons";
 @use "emerald/dashcard";


### PR DESCRIPTION
Fixes JETPACK-1508

## Summary

Aligns the Jetpack CRM admin footer with the unified Jetpack admin-page footer used across the other Jetpack products, following the same pure-PHP/CSS approach as the header work in [jetpack#47871](https://github.com/Automattic/jetpack/pull/47871). This standalone repo doesn't ship `@automattic/jetpack-components`, so the React `JetpackFooter` component isn't available. The look is reproduced with PHP markup and SCSS instead.

**Before:** "Thank you for using Jetpack CRM." + "Jetpack CRM v6.8.1"
<img width="1207" height="362" alt="image" src="https://github.com/user-attachments/assets/c71d0a6b-afe5-452f-8114-1cda794c8a1d" />


**After:** Jetpack logo + "Jetpack" (left) · Automattic "An Automattic Airline" byline (right)
<img width="1208" height="628" alt="image" src="https://github.com/user-attachments/assets/5ff04ce8-6a18-4ded-a984-51265a025a13" />
<img width="351" height="135" alt="image" src="https://github.com/user-attachments/assets/e39ad18b-ea4d-455d-8bd8-d5a4768b82b2" />


## Changes

- **`includes/ZeroBSCRM.AdminStyling.php`** — swap the two footer filters' output to the Jetpack logo (left) and Automattic byline (right).
- **`sass/emerald/_jpcrm_footer.scss`** (new) — restyle `#wpfooter` on CRM pages: top border, `#fcfcfc` surface, flex layout, byline pushed right. WPDS tokens with hardcoded fallbacks, mirroring `_jpcrm_top_menu.scss`. Three of them are written as `var(--short, var(--long, #hex))` because this repo still pins `@wordpress/theme@0.13.0`, which only defines the short-form names. They pick up the long-form names automatically once #13 bumps the package.
- **`sass/jpcrm-emerald.scss`** — `@use` the new partial.
- **`admin/settings/general.page.php`** — the "Show admin credits" description promised "Powered by Jetpack CRM" footers. It doesn't do that any more, so it now describes the Jetpack and Automattic logos.

## Gating (unchanged)

All the existing conditions are preserved. The footer renders only on CRM admin pages, and only when the **"Show admin credits"** setting (`showpoweredby_admin`) is on. The branding sits inside `##WLREMOVE` blocks so it's stripped from white-label builds.

To be clear about where that happens: nothing in this repo strips the markers. `scripts/build-plugin.sh` leaves them alone, and the stripping is done by the white-label pipeline outside this repo. So it can't be verified by running `make release` here.

The SCSS is guarded with `#wpfooter:has(.jetpack-footer__logo)` so no border or surface is drawn when the footer is empty (credits off, or white label).

## Two deliberate behaviour changes

- **The CRM version no longer shows anywhere in the admin UI.** That matches the other Jetpack products, which don't show a version in the footer either. `update_footer` still runs at priority 11, so the WordPress version stays suppressed on CRM pages as before. The plugin version is still on the Plugins screen.
- **The footer is now visible below 782px.** Core hides `#wpfooter` at that width; the new base rule outranks it. This is what the unified footer does, so it's intentional, but it isn't obvious from the diff.

## Testing

- Verified on a live install in the normal branded state (logo + byline, `#fcfcfc` surface, computed values matching the real My Jetpack footer).
- Toggled **"Show admin credits"** off. The footer cleanly reverts to the default empty WP footer, with no leftover styling.
- Emulated the white-label build by stripping every `##WLREMOVE` block. The footer renders empty with **no Jetpack/Automattic branding leak** and no orphaned styling, the header correctly falls back (no "CRM" text), and `php -l` is clean on the stripped file.

Note: the compiled CSS under `css/` is gitignored in this repo, so this PR is source-only. The SCSS is compiled at build/release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
