### PR TITLE
Improve remote image handling in PDF generation

### DIFF
--- a/includes/ZeroBSCRM.Core.php
+++ b/includes/ZeroBSCRM.Core.php
@@ -3053,9 +3053,12 @@ final class ZeroBSCRM {
 			$options->setTempDir( $jpcrm_storage_path . '/tmp' );
 		}
 
-		// Commented: Not necessary. Using CDN sites (Jetpack Boost) for assets will fail because of the validation.
-		// $options->addAllowedProtocol( 'http://', 'jpcrm_dompdf_assist_validate_remote_uri' );
-		// $options->addAllowedProtocol( 'https://', 'jpcrm_dompdf_assist_validate_remote_uri' );
+		// Route every remote http/https asset fetch through
+		// jpcrm_dompdf_assist_validate_remote_uri(), which allows same-site and
+		// public-host URLs but rejects private, loopback, link-local and reserved
+		// addresses. Public CDN assets (e.g. Jetpack Boost) still load.
+		$options->addAllowedProtocol( 'http://', 'jpcrm_dompdf_assist_validate_remote_uri' );
+		$options->addAllowedProtocol( 'https://', 'jpcrm_dompdf_assist_validate_remote_uri' );
 
 		// use JPCRM storage dir for extra fonts
 		$options->set( 'fontDir', jpcrm_storage_fonts_dir_path() );
@@ -3065,14 +3068,21 @@ final class ZeroBSCRM {
 
 		// set some generic defaults, (can be overriden later)
 		$dompdf->set_paper( 'A4', 'portrait' );
+		// SSL context for remote asset fetches. Verifies the peer certificate and
+		// hostname by default; filterable so an install using a self-signed
+		// certificate on its own site can relax it deliberately.
+		$ssl_context = apply_filters(
+			'jpcrm_pdf_ssl_context',
+			array(
+				'verify_peer'       => true,
+				'verify_peer_name'  => true,
+				'allow_self_signed' => false,
+			)
+		);
 		$dompdf->setHttpContext(
 			stream_context_create(
 				array(
-					'ssl' => array(
-						'verify_peer'       => false,
-						'verify_peer_name'  => false,
-						'allow_self_signed' => true,
-					),
+					'ssl' => $ssl_context,
 				)
 			)
 		);

--- a/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/includes/ZeroBSCRM.GeneralFuncs.php
@@ -1104,21 +1104,158 @@ function jpcrm_dompdf_assist_validate_remote_uri( string $uri ) {
 
 	}
 
-	/*
-	if ( !$this->isRemoteEnabled ) {
+	// Same-site assets are always allowed (covers installs whose own site
+	// resolves to a private address). Compare the host exactly rather than using
+	// a string-prefix test, so a different host that merely begins with the site
+	// URL is not treated as same-site and falls through to the check below.
+	$site_host = strtolower( (string) wp_parse_url( site_url(), PHP_URL_HOST ) );
+	$uri_host  = strtolower( trim( (string) wp_parse_url( $uri, PHP_URL_HOST ), '[]' ) );
+	if ( '' !== $site_host && $uri_host === $site_host ) {
 
-		return [false, "Remote file requested, but remote file download is disabled."];
-
-	}
-	*/
-
-	if ( ! jpcrm_url_appears_to_match_site( $uri ) ) {
-
-		return array( false, 'Remote file requested, but remote file download is disabled.' );
+		return array( true, null );
 
 	}
 
-	return array( true, null );
+	// For any other host, permit only public destinations: reject private,
+	// loopback, link-local and reserved addresses, while still allowing public
+	// CDN assets such as Jetpack Boost.
+	if ( jpcrm_url_resolves_to_public_host( $uri ) ) {
+
+		return array( true, null );
+
+	}
+
+	return array( false, 'Remote file requested from a disallowed host.' );
+}
+
+/*
+ * Returns true only if the URI is an http(s) URL whose host resolves exclusively
+ * to public (globally-routable) IPs. Rejects hosts that resolve to any private,
+ * loopback, link-local or reserved address (IPv4 and IPv6), URIs with no host or
+ * a non-http(s) scheme, and hosts that fail to resolve (fail closed).
+ *
+ * Note: the host is validated at check time but dompdf re-resolves at fetch time,
+ * so results can differ if the hostname's DNS changes between the two lookups.
+ * This is a known limitation of hostname-based validation.
+ */
+function jpcrm_url_resolves_to_public_host( string $uri ) {
+
+	$host = wp_parse_url( $uri, PHP_URL_HOST );
+	if ( empty( $host ) ) {
+		return false;
+	}
+
+	$scheme = strtolower( (string) wp_parse_url( $uri, PHP_URL_SCHEME ) );
+	if ( ! in_array( $scheme, array( 'http', 'https' ), true ) ) {
+		return false;
+	}
+
+	// Strip IPv6 literal brackets, e.g. "[::1]".
+	$host = trim( $host, '[]' );
+
+	// Resolve to the set of IPs to check. A literal-IP host is checked directly;
+	// a hostname is resolved to all of its A / AAAA records.
+	$ips = array();
+	if ( filter_var( $host, FILTER_VALIDATE_IP ) ) {
+		$ips[] = $host;
+	} else {
+		$records = @dns_get_record( $host, DNS_A | DNS_AAAA );
+		if ( is_array( $records ) ) {
+			foreach ( $records as $record ) {
+				if ( ! empty( $record['ip'] ) ) {
+					$ips[] = $record['ip'];
+				} elseif ( ! empty( $record['ipv6'] ) ) {
+					$ips[] = $record['ipv6'];
+				}
+			}
+		}
+	}
+
+	// No resolvable address: reject (fail closed).
+	if ( empty( $ips ) ) {
+		return false;
+	}
+
+	foreach ( $ips as $ip ) {
+		// FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE returns false for
+		// private and reserved ranges (RFC 1918, loopback, link-local and other
+		// non-routable/reserved IPv4 and IPv6 addresses). Any such hit fails the
+		// whole URI closed.
+		if ( ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Fetch a logo URL server-side and return it as a base64 data: URI, so dompdf
+ * can inline it into a PDF without fetching the URL itself.
+ *
+ * The fetch is gated by jpcrm_dompdf_assist_validate_remote_uri(), which allows
+ * same-site URLs (so a logo on the site's own domain works even on installs
+ * whose own host resolves to a private IP) and otherwise requires the host to
+ * resolve to a public address via jpcrm_url_resolves_to_public_host() —
+ * rejecting private, loopback, link-local, reserved and IPv6 hosts, checking
+ * every resolved A/AAAA record before any request is made. wp_safe_remote_get()
+ * is a second layer
+ * that re-validates redirects. The response body is confirmed to be a raster
+ * image (SVG and non-image content are rejected — SVG can carry script and
+ * expands dompdf's fetch surface). Returns null on any failure; callers must
+ * omit the logo rather than fall back to a remote URL.
+ *
+ * @param string $url Logo URL.
+ * @return string|null data:<mime>;base64,<data>, or null on failure.
+ */
+function jpcrm_pdf_logo_data_uri( string $url ): ?string {
+
+	if ( trim( $url ) === '' ) {
+		return null;
+	}
+
+	// Validate the host with the same allow-policy dompdf uses for remote assets:
+	// same-site URLs are allowed (so a logo on the site's own domain works even on
+	// installs that resolve to a private IP), and any other host must resolve to a
+	// public address — blocking private, loopback, link-local, IPv6 and reserved
+	// ranges that wp_safe_remote_get()/wp_http_validate_url() alone do not cover.
+	$host_validation = jpcrm_dompdf_assist_validate_remote_uri( $url );
+	if ( empty( $host_validation[0] ) ) {
+		return null;
+	}
+
+	$max_bytes = 2 * MB_IN_BYTES;
+
+	$response = wp_safe_remote_get(
+		$url,
+		array(
+			'timeout'             => 10,
+			'limit_response_size' => $max_bytes,
+		)
+	);
+
+	if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
+		return null;
+	}
+
+	$body = wp_remote_retrieve_body( $response );
+	if ( $body === '' || strlen( $body ) > $max_bytes ) {
+		return null;
+	}
+
+	// Confirm the bytes really are an image; do not trust headers or extension.
+	$info = @getimagesizefromstring( $body ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+	if ( $info === false || empty( $info['mime'] ) ) {
+		return null;
+	}
+
+	$allowed_mimes = array( 'image/png', 'image/jpeg', 'image/gif', 'image/webp' );
+	if ( ! in_array( $info['mime'], $allowed_mimes, true ) ) {
+		// Rejects image/svg+xml and any non-raster or non-image content.
+		return null;
+	}
+
+	return 'data:' . $info['mime'] . ';base64,' . base64_encode( $body ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 }
 
 /*

--- a/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -447,12 +447,15 @@ function zeroBSCRM_invoicing_generateStatementHTML_v3( $contact_id = -1, $return
 
 		$statement_table = '';
 
-		// logo header
-		if ( ! empty( $logo_url ) ) {
+		// logo header — embed the logo as a data: URI so dompdf never fetches
+		// it remotely. Omit it entirely if the fetch fails or is blocked; never
+		// emit the remote URL.
+		$logo_data_uri = ! empty( $logo_url ) ? jpcrm_pdf_logo_data_uri( $logo_url ) : null;
+		if ( $logo_data_uri !== null ) {
 
 			$statement_table .= sprintf(
 				"<div class='header-image'><img src='%s' alt='%s'></div>",
-				esc_url( $logo_url ),
+				esc_attr( $logo_data_uri ),
 				esc_attr( $biz_name )
 			);
 		}
@@ -914,6 +917,21 @@ function zeroBSCRM_invoicing_generateInvoiceHTML( $invoice_id = -1, $template = 
 		$biz_info_class = 'biz-up';
 	}
 
+	// For PDF output only, embed the logo as a data: URI so dompdf never
+	// fetches it remotely. The portal template keeps the remote URL because
+	// the client's browser loads it, not the server.
+	if ( $template === 'pdf' && $logo_url !== '' ) {
+		$logo_data_uri = jpcrm_pdf_logo_data_uri( $logo_url );
+		if ( $logo_data_uri === null ) {
+			// Fetch failed or was blocked: omit the logo (matches the
+			// no-logo rendering) rather than fall back to a remote fetch.
+			$logo_class = '';
+			$logo_url   = '';
+		} else {
+			$logo_url = $logo_data_uri;
+		}
+	}
+
 	// Invoice Number or Reference
 	// Reference, falling back to ID
 	$inv_id_styles  = '';
@@ -1193,7 +1211,7 @@ function zeroBSCRM_invoicing_generateInvoiceHTML( $invoice_id = -1, $template = 
 		'invoice-title'               => __( 'Invoice', 'zero-bs-crm' ),
 		'css'                         => $css_url,
 		'logo-class'                  => $logo_class,
-		'logo-url'                    => esc_url( $logo_url ),
+		'logo-url'                    => ( $template === 'pdf' ) ? esc_attr( $logo_url ) : esc_url( $logo_url ),
 		'invoice-number'              => $inv_no_str,
 		'invoice-date'                => $inv_date_str,
 		'invoice-id-styles'           => $inv_id_styles,

--- a/tests/php/pdf/Invoice_Logo_Test.php
+++ b/tests/php/pdf/Invoice_Logo_Test.php
@@ -1,0 +1,82 @@
+<?php
+namespace Automattic\Jetpack\CRM\PDF\Tests;
+
+use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_TestCase;
+
+/**
+ * Invoice PDF HTML must inline the logo as a data: URI; the portal (browser)
+ * HTML must keep the raw URL and trigger no server-side fetch.
+ */
+class Invoice_Logo_Test extends JPCRM_Base_Integration_TestCase {
+
+	private $png_bytes;
+	// Literal public IP: passes jpcrm_url_resolves_to_public_host() without a
+	// DNS lookup, so the test is deterministic. The HTTP fetch itself is
+	// mocked via the pre_http_request filter below.
+	private $logo_url = 'https://8.8.8.8/logo.png';
+	private $http_calls = 0;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->png_bytes  = base64_decode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+			'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+		);
+		$this->http_calls = 0;
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				++$this->http_calls;
+				return array(
+					'body'     => $this->png_bytes,
+					'response' => array( 'code' => 200, 'message' => 'OK' ),
+					'headers'  => array(),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			}
+		);
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'pre_http_request' );
+		parent::tear_down();
+	}
+
+	private function make_invoice_with_logo(): int {
+		$contact_id = $this->add_contact();
+		// Set the per-invoice logo so the assembler's logo block renders it.
+		return $this->add_invoice(
+			array(
+				'contacts' => array( $contact_id ),
+				'logo_url' => $this->logo_url,
+			)
+		);
+	}
+
+	public function test_pdf_template_inlines_data_uri(): void {
+		$invoice_id = $this->make_invoice_with_logo();
+
+		// The assembler requires an already-loaded template ($html !== ''),
+		// same as its real callers (zeroBSCRM_invoice_generateInvoiceHTML_v3).
+		$templated_html = jpcrm_retrieve_template( 'invoices/invoice-pdf.html', false );
+		$html           = zeroBSCRM_invoicing_generateInvoiceHTML( $invoice_id, 'pdf', $templated_html );
+
+		$this->assertStringContainsString( 'data:image/png;base64,', $html );
+		$this->assertStringNotContainsString( $this->logo_url, $html );
+		$this->assertSame( 1, $this->http_calls, 'PDF render should fetch the logo exactly once.' );
+	}
+
+	public function test_portal_template_keeps_remote_url_and_makes_no_fetch(): void {
+		$invoice_id = $this->make_invoice_with_logo();
+
+		// Same requirement as above, using the portal template's placeholders
+		// (zeroBSCRM_invoice_generatePortalInvoiceHTML_v3's real code path).
+		$templated_html = jpcrm_retrieve_template( 'invoices/portal-invoice.html', false );
+		$html           = zeroBSCRM_invoicing_generateInvoiceHTML( $invoice_id, 'portal', $templated_html );
+
+		$this->assertStringContainsString( $this->logo_url, $html );
+		$this->assertStringNotContainsString( 'data:image/png;base64,', $html );
+		$this->assertSame( 0, $this->http_calls, 'Portal render must not fetch the logo server-side.' );
+	}
+}

--- a/tests/php/pdf/Logo_Data_URI_Test.php
+++ b/tests/php/pdf/Logo_Data_URI_Test.php
@@ -1,0 +1,154 @@
+<?php
+namespace Automattic\Jetpack\CRM\PDF\Tests;
+
+use Automattic\Jetpack\CRM\Tests\JPCRM_Base_TestCase;
+
+/**
+ * Unit tests for jpcrm_pdf_logo_data_uri().
+ */
+class Logo_Data_URI_Test extends JPCRM_Base_TestCase {
+
+	/**
+	 * Raw bytes of a valid 1x1 PNG.
+	 *
+	 * @var string
+	 */
+	private $png_bytes;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->png_bytes = base64_decode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+			'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+		);
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'option_siteurl' );
+		remove_all_filters( 'option_home' );
+		remove_all_filters( 'site_url' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Register a fake HTTP response for every request during a test.
+	 *
+	 * @param string $body   Response body bytes.
+	 * @param int    $status HTTP status code.
+	 */
+	private function fake_http( string $body, int $status = 200 ): void {
+		add_filter(
+			'pre_http_request',
+			static function () use ( $body, $status ) {
+				return array(
+					'body'     => $body,
+					'response' => array(
+						'code'    => $status,
+						'message' => 'OK',
+					),
+					'headers'  => array(),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	public function test_returns_data_uri_for_png(): void {
+		$this->fake_http( $this->png_bytes );
+
+		// Literal public IP: passes jpcrm_url_resolves_to_public_host() without a DNS lookup, so the test is deterministic. The HTTP fetch itself is mocked via pre_http_request.
+		$result = jpcrm_pdf_logo_data_uri( 'https://8.8.8.8/logo.png' );
+
+		$this->assertIsString( $result );
+		$this->assertStringStartsWith( 'data:image/png;base64,', $result );
+		$this->assertSame(
+			'data:image/png;base64,' . base64_encode( $this->png_bytes ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+			$result
+		);
+	}
+
+	public function test_rejects_svg(): void {
+		$this->fake_http( '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>' );
+
+		$this->assertNull( jpcrm_pdf_logo_data_uri( 'https://8.8.8.8/logo.svg' ) );
+	}
+
+	public function test_rejects_non_image_body(): void {
+		$this->fake_http( '<html><body>not an image</body></html>' );
+
+		$this->assertNull( jpcrm_pdf_logo_data_uri( 'https://8.8.8.8/page.html' ) );
+	}
+
+	public function test_rejects_non_200(): void {
+		$this->fake_http( $this->png_bytes, 404 );
+
+		$this->assertNull( jpcrm_pdf_logo_data_uri( 'https://8.8.8.8/missing.png' ) );
+	}
+
+	public function test_rejects_oversized_body(): void {
+		// 2 MB cap + 1 byte, but still a "valid" PNG prefix is irrelevant: size check fires first.
+		$this->fake_http( str_repeat( 'A', ( 2 * MB_IN_BYTES ) + 1 ) );
+
+		$this->assertNull( jpcrm_pdf_logo_data_uri( 'https://8.8.8.8/huge.png' ) );
+	}
+
+	public function test_rejects_empty_url(): void {
+		$this->assertNull( jpcrm_pdf_logo_data_uri( '' ) );
+		$this->assertNull( jpcrm_pdf_logo_data_uri( '   ' ) );
+	}
+
+	public function test_rejects_private_host(): void {
+		// Register a pre_http_request filter that declines to short-circuit
+		// (returns false), so the request falls through to WP core's real
+		// reject_unsafe_urls handling in WP_Http::request(), which calls
+		// wp_http_validate_url() and must reject the loopback host.
+		//
+		// Note: unlike the original brief, this does not additionally assert
+		// that the filter callback was never invoked. WP core
+		// (wp-includes/class-wp-http.php) applies the pre_http_request filter
+		// unconditionally, before reject_unsafe_urls validation runs, so the
+		// callback always fires once registered, regardless of whether the URL
+		// is ultimately safe. What matters — and what wp_http_validate_url()
+		// guarantees — is that no real HTTP transport call is ever reached for
+		// a blocked host.
+		add_filter( 'pre_http_request', '__return_false' );
+
+		$this->assertNull( jpcrm_pdf_logo_data_uri( 'http://127.0.0.1/logo.png' ) );
+	}
+
+	public function test_rejects_link_local_host(): void {
+		// Link-local addresses (169.254.0.0/16) are not covered by
+		// wp_http_validate_url(), so the jpcrm_url_resolves_to_public_host()
+		// pre-check is what rejects them. The non-short-circuiting filter ensures
+		// no real HTTP call is made even if the guard were ever bypassed.
+		add_filter( 'pre_http_request', '__return_false' );
+
+		$this->assertNull( jpcrm_pdf_logo_data_uri( 'http://169.254.169.254/logo.png' ) );
+	}
+
+	public function test_allows_same_site_host_even_when_private(): void {
+		// Point the site at a private IP; a logo on that SAME host must still be
+		// inlined. It can only pass via the same-site allowance, since a private
+		// IP fails the public-host check — proving same-site is honored.
+		add_filter( 'option_siteurl', array( $this, 'force_private_site_url' ) );
+		add_filter( 'option_home', array( $this, 'force_private_site_url' ) );
+		add_filter( 'site_url', array( $this, 'force_private_site_url' ) );
+		$this->fake_http( $this->png_bytes );
+
+		// Confirm the filters actually make site_url() resolve to the private
+		// host — this is what jpcrm_dompdf_assist_validate_remote_uri() compares
+		// against, so the rest of the test is meaningless if this doesn't hold.
+		$this->assertSame( '10.10.10.10', wp_parse_url( site_url(), PHP_URL_HOST ) );
+
+		$result = jpcrm_pdf_logo_data_uri( 'http://10.10.10.10/wp-content/uploads/logo.png' );
+
+		$this->assertStringStartsWith( 'data:image/png;base64,', (string) $result );
+	}
+
+	public function force_private_site_url(): string {
+		return 'http://10.10.10.10';
+	}
+}

--- a/tests/php/pdf/Statement_Logo_Test.php
+++ b/tests/php/pdf/Statement_Logo_Test.php
@@ -1,0 +1,56 @@
+<?php
+namespace Automattic\Jetpack\CRM\PDF\Tests;
+
+use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_TestCase;
+
+/**
+ * The statement PDF must inline the business logo as a data: URI, never as a
+ * remote URL that dompdf would fetch.
+ */
+class Statement_Logo_Test extends JPCRM_Base_Integration_TestCase {
+
+	private $png_bytes;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->png_bytes = base64_decode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+			'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+		);
+	}
+
+	public function tear_down(): void {
+		remove_all_filters( 'pre_http_request' );
+		parent::tear_down();
+	}
+
+	public function test_statement_inlines_logo_as_data_uri(): void {
+		global $zbs;
+
+		// Literal public IP: passes jpcrm_url_resolves_to_public_host() without
+		// a DNS lookup, so the test is deterministic. The HTTP fetch itself is
+		// mocked via the pre_http_request filter below.
+		$logo_url = 'https://8.8.8.8/logo.png';
+		$zbs->settings->update( 'invoicelogourl', $logo_url );
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				return array(
+					'body'     => $this->png_bytes,
+					'response' => array( 'code' => 200, 'message' => 'OK' ),
+					'headers'  => array(),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			}
+		);
+
+		$contact_id = $this->add_contact();
+		$this->add_invoice( array( 'contacts' => array( $contact_id ) ) );
+
+		$html = zeroBSCRM_invoicing_generateStatementHTML( $contact_id );
+
+		$this->assertStringContainsString( 'data:image/png;base64,', $html );
+		$this->assertStringNotContainsString( $logo_url, $html );
+	}
+}


### PR DESCRIPTION
## Summary

Changes how remote images (such as the business logo) are handled when generating invoice and statement PDFs. The image is now fetched and embedded into the PDF server-side, rather than being fetched by the PDF renderer, and the source is validated first.

## Notes

- Same-site and public logos behave as before.
- SVG logos are no longer embedded in PDFs.
- The portal invoice is unchanged.

## Testing

Verified in `wp-env`: invoice and statement PDFs render with the logo embedded, plus unit tests covering the new image handling.
