### PR TITLE
Release Jetpack CRM 6.8.2

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install JS dependencies
         run: npm install --no-audit --no-fund
       - name: Install PHP dependencies
-        run: composer install --no-ansi --no-interaction --prefer-dist --no-progress
+        run: composer install --no-dev --no-ansi --no-interaction --prefer-dist --no-progress
       - name: Setup Git
         run: |
           git config user.name "Jetpack CRM Bot"


### PR DESCRIPTION
Re-cut of 6.8.2. #11 merged fine but the deploy workflow failed on `Install PHP dependencies`. The job pins PHP 7.4 and runs `composer install` without `--no-dev`, so it tries to install the dev dependencies and those need PHP 8.3 or newer.

Nothing was published by that run, no tag, no GitHub release, nothing on WordPress.org.

This branch has the one line fix, adding `--no-dev` to the composer step in `.github/workflows/create-release.yml`. The root `composer install` isn't used by the release build anyway, `scripts/build-plugin.sh` copies the manifests into the staged plugin directory and runs its own `composer install --no-dev` there.

The version files are already at 6.8.2 on trunk from #11, so merging this tags the release, builds the zip and deploys.

### Release Notes
---
* Improve remote image handling in PDF generation (#10)
---
