### PR TITLE
Fix date custom fields being dropped by the create/update API

### DIFF
--- a/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -2731,14 +2731,42 @@ function zeroBS_buildObjArr( $arraySource = array(), $startingArray = array(), $
 						$retArray[ $outputPrefix . $fK ] = sanitize_textarea_field( $arraySource[ $fieldPrefix . $fK ] );
 						break;
 
+					// #jpcrmidempotentdates
+					// The date and datetime branches below accept an already-converted UTS and pass it
+					// through untouched, so that normalising twice matches normalising once.
+					//
+					// The contact and company create/update API endpoints normalise their payload here,
+					// then hand the result to zeroBS_addUpdateCustomer()/zeroBS_addUpdateCompany(), which
+					// normalise it a second time with $removeEmpties on. Without the pass-through the
+					// second pass cannot read the timestamp the first pass produced: the conversion fails,
+					// and the field is stripped before it reaches the DAL, silently dropping the value.
+					//
+					// The check has to come before conversion rather than after it. zeroBSCRM_locale_dateToUTS()
+					// falls back to strtotime(), which reads a negative timestamp as a relative offset and
+					// returns roughly the current time, so a pre-1970 datetime would never reach a
+					// post-conversion guard.
 					case 'date':
-						$safe_text = sanitize_text_field( $arraySource[ $fieldPrefix . $fK ] ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+						$raw_value = $arraySource[ $fieldPrefix . $fK ]; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+
+						if ( jpcrm_value_is_uts( $raw_value ) ) {
+							$retArray[ $outputPrefix . $fK ] = (int) $raw_value; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+							break;
+						}
+
+						$safe_text = sanitize_text_field( $raw_value );
 
 						$retArray[ $outputPrefix . $fK ] = jpcrm_date_str_to_uts( $safe_text, '!Y-m-d', true ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 						break;
 
 					case 'datetime':
-						$retArray[ $outputPrefix . $fK ] = sanitize_text_field( $arraySource[ $fieldPrefix . $fK ] );
+						$raw_value = $arraySource[ $fieldPrefix . $fK ]; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+
+						if ( jpcrm_value_is_uts( $raw_value ) ) {
+							$retArray[ $outputPrefix . $fK ] = (int) $raw_value; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+							break;
+						}
+
+						$retArray[ $outputPrefix . $fK ] = sanitize_text_field( $raw_value );
 
 						// translate datetime to UTS (without time)
 						// ... by default from DAL3.0

--- a/includes/jpcrm-localisation.php
+++ b/includes/jpcrm-localisation.php
@@ -95,6 +95,37 @@ function jpcrm_uts_to_time_str( $timestamp, $format = false ) {
 }
 
 /**
+ * Checks whether a value is already a UTS, rather than a date string awaiting conversion.
+ *
+ * The date conversion functions here cannot read their own output: given a
+ * timestamp, DateTime::createFromFormat() fails and they return false. This lets
+ * callers which may be handed an already-converted value treat that value as a
+ * no-op instead of losing it.
+ *
+ * An int is accepted as-is, because that is what the conversion functions return.
+ * A string must hold nine or more digits (optionally signed), which is a plausible
+ * timestamp. That floor stops a short numeric string (a date custom field submitted
+ * as "2026", say) being read as a timestamp in 1970. Such a string fails to parse as
+ * a date today and continues to.
+ *
+ * @param mixed $value Value to test.
+ *
+ * @return bool True if the value is already a UTS.
+ */
+function jpcrm_value_is_uts( $value ) {
+
+	if ( is_int( $value ) ) {
+		return true;
+	}
+
+	if ( ! is_string( $value ) ) {
+		return false;
+	}
+
+	return preg_match( '/^-?[0-9]{9,}$/', $value ) === 1;
+}
+
+/**
  * Creates a UTS from a date time string
  *
  * @param string $datetime_str String containing date and time (in WP timezone).

--- a/tests/php/class-jpcrm-base-integration-testcase.php
+++ b/tests/php/class-jpcrm-base-integration-testcase.php
@@ -86,4 +86,45 @@ abstract class JPCRM_Base_Integration_TestCase extends JPCRM_Base_TestCase {
 
 		return wp_create_user( 'testuser', 'password', 'user@demo.com' );
 	}
+
+	/**
+	 * Register a custom field against one or more object types and rebuild the field globals.
+	 *
+	 * Custom fields are stored twice: once per object type for DAL3, and once in the legacy
+	 * `customfields` setting. zeroBSCRM_unpackCustomFields() gates the DAL3 overload on the
+	 * object key existing in the legacy setting, so both are needed before the field reaches
+	 * $zbsCustomerFields / $zbsCompanyFields.
+	 *
+	 * @param string $slug        Field slug, e.g. 'contract-date'.
+	 * @param string $type        Field type, e.g. 'date'. Must be in zeroBSCRM_customfields_acceptableCFTypes().
+	 * @param string $label       Human readable field name.
+	 * @param array  $object_keys Legacy object key => object type ID, e.g. array( 'customers' => ZBS_TYPE_CONTACT ).
+	 *
+	 * @return void
+	 */
+	public function register_custom_field( $slug, $type, $label, array $object_keys ) {
+		global $zbs;
+
+		$field_definition = array( $type, $label, '', $slug );
+
+		$legacy_setting = array();
+
+		foreach ( $object_keys as $object_key => $obj_type_id ) {
+			$zbs->DAL->updateActiveCustomFields( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				array(
+					'objtypeid' => $obj_type_id,
+					'fields'    => array( $slug => $field_definition ),
+				)
+			);
+
+			$legacy_setting[ $object_key ] = array( $field_definition );
+		}
+
+		$zbs->settings->update( 'customfields', $legacy_setting );
+
+		// Same order as ZeroBSCRM.Core.php: build the globals from the models, then overlay
+		// the custom fields.
+		zeroBSCRM_fields_initialise();
+		zeroBSCRM_unpackCustomFields();
+	}
 }

--- a/tests/php/entities/Object_Array_Builder_Date_Test.php
+++ b/tests/php/entities/Object_Array_Builder_Date_Test.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack\CRM\Entities\Tests;
 
 use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 
 /**
@@ -91,6 +92,7 @@ class Object_Array_Builder_Date_Test extends JPCRM_Base_Integration_TestCase {
 	 *
 	 * @param int $obj_type Object type constant.
 	 */
+	#[DataProvider( 'object_type_provider' )]
 	#[TestDox( 'A date custom field survives the second normalisation pass.' )]
 	public function test_date_custom_field_survives_second_pass( $obj_type ) {
 		$expected = jpcrm_date_str_to_uts( '2026-07-23', '!Y-m-d', true );
@@ -108,6 +110,7 @@ class Object_Array_Builder_Date_Test extends JPCRM_Base_Integration_TestCase {
 	 *
 	 * @param int $obj_type Object type constant.
 	 */
+	#[DataProvider( 'object_type_provider' )]
 	#[TestDox( 'A datetime custom field survives the second normalisation pass.' )]
 	public function test_datetime_custom_field_survives_second_pass( $obj_type ) {
 		$first_pass = zeroBS_buildObjArr( array( 'signed-at' => '2026-07-23 14:30' ), array(), '', 'zbsc_', false, $obj_type, true );
@@ -135,6 +138,7 @@ class Object_Array_Builder_Date_Test extends JPCRM_Base_Integration_TestCase {
 
 		$result = $this->build_twice( array( 'contract-date' => '1950-01-01' ), ZBS_TYPE_CONTACT );
 
+		$this->assertArrayHasKey( 'contract-date', $result, 'The pre-1970 date custom field was stripped before reaching the DAL.' );
 		$this->assertSame( $expected, $result['contract-date'] );
 	}
 
@@ -148,6 +152,7 @@ class Object_Array_Builder_Date_Test extends JPCRM_Base_Integration_TestCase {
 		$once  = zeroBS_buildObjArr( $payload, array(), '', '', true, ZBS_TYPE_CONTACT, false );
 		$twice = zeroBS_buildObjArr( $once, array(), '', '', true, ZBS_TYPE_CONTACT, false );
 
+		$this->assertArrayHasKey( 'contract-date', $twice, 'The second pass stripped the date custom field.' );
 		$this->assertSame( $once['contract-date'], $twice['contract-date'] );
 	}
 

--- a/tests/php/entities/Object_Array_Builder_Date_Test.php
+++ b/tests/php/entities/Object_Array_Builder_Date_Test.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Automattic\Jetpack\CRM\Entities\Tests;
+
+use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Tests date and datetime normalisation in the shared object array builder.
+ *
+ * The contact and company create/update API endpoints normalise their payload with
+ * zeroBS_buildObjArr(), then hand the result to zeroBS_addUpdateCustomer()/
+ * zeroBS_addUpdateCompany(), which normalise it a second time with $removeEmpties on.
+ * Normalising an already-normalised value therefore has to be a no-op, or the second
+ * pass strips the field and the value never reaches the DAL.
+ *
+ * @covers ::zeroBS_buildObjArr
+ */
+class Object_Array_Builder_Date_Test extends JPCRM_Base_Integration_TestCase {
+
+	/**
+	 * Field globals as they were before a test replaced them.
+	 *
+	 * @var array
+	 */
+	private $original_field_globals = array();
+
+	/**
+	 * Register a date and a datetime custom field against contacts and companies.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		foreach ( array( 'zbsCustomerFields', 'zbsCompanyFields' ) as $global_name ) {
+			$this->original_field_globals[ $global_name ] = $GLOBALS[ $global_name ] ?? array();
+
+			$GLOBALS[ $global_name ]['contract-date'] = array( 'date', 'Contract Date', '' );
+			$GLOBALS[ $global_name ]['signed-at']     = array( 'datetime', 'Signed At', '' );
+		}
+	}
+
+	/**
+	 * Restore the field globals.
+	 *
+	 * @return void
+	 */
+	public function tear_down(): void {
+		foreach ( $this->original_field_globals as $global_name => $value ) {
+			$GLOBALS[ $global_name ] = $value;
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Run the two normalisation passes an API create/update performs.
+	 *
+	 * Mirrors api/create_customer.php and api/create_company.php, which build with an
+	 * empty input prefix and a 'zbsc_' output prefix, followed by zeroBS_addUpdateCustomer(),
+	 * which rebuilds with a 'zbsc_' input prefix, an empty output prefix and $removeEmpties on.
+	 *
+	 * @param array $payload  Incoming API payload.
+	 * @param int   $obj_type Object type constant.
+	 *
+	 * @return array The twice-normalised array.
+	 */
+	private function build_twice( array $payload, $obj_type ) {
+		$first_pass = zeroBS_buildObjArr( $payload, array(), '', 'zbsc_', false, $obj_type, true );
+
+		return zeroBS_buildObjArr( $first_pass, array(), 'zbsc_', '', true, $obj_type, false );
+	}
+
+	/**
+	 * Object types the builder is shared across, for the cases which apply to both.
+	 *
+	 * @return array
+	 */
+	public static function object_type_provider() {
+		return array(
+			'contact' => array( ZBS_TYPE_CONTACT ),
+			'company' => array( ZBS_TYPE_COMPANY ),
+		);
+	}
+
+	/**
+	 * @testdox A date custom field survives the second normalisation pass.
+	 *
+	 * @dataProvider object_type_provider
+	 *
+	 * @param int $obj_type Object type constant.
+	 */
+	#[TestDox( 'A date custom field survives the second normalisation pass.' )]
+	public function test_date_custom_field_survives_second_pass( $obj_type ) {
+		$expected = jpcrm_date_str_to_uts( '2026-07-23', '!Y-m-d', true );
+
+		$result = $this->build_twice( array( 'contract-date' => '2026-07-23' ), $obj_type );
+
+		$this->assertArrayHasKey( 'contract-date', $result, 'The date custom field was stripped before reaching the DAL.' );
+		$this->assertSame( $expected, $result['contract-date'] );
+	}
+
+	/**
+	 * @testdox A datetime custom field survives the second normalisation pass.
+	 *
+	 * @dataProvider object_type_provider
+	 *
+	 * @param int $obj_type Object type constant.
+	 */
+	#[TestDox( 'A datetime custom field survives the second normalisation pass.' )]
+	public function test_datetime_custom_field_survives_second_pass( $obj_type ) {
+		$first_pass = zeroBS_buildObjArr( array( 'signed-at' => '2026-07-23 14:30' ), array(), '', 'zbsc_', false, $obj_type, true );
+
+		$this->assertIsInt( $first_pass['zbsc_signed-at'], 'The first pass did not produce a timestamp; the fixture format may not match the site date format.' );
+
+		$result = zeroBS_buildObjArr( $first_pass, array(), 'zbsc_', '', true, $obj_type, false );
+
+		$this->assertArrayHasKey( 'signed-at', $result, 'The datetime custom field was stripped before reaching the DAL.' );
+		$this->assertSame( $first_pass['zbsc_signed-at'], $result['signed-at'] );
+	}
+
+	/**
+	 * A pre-1970 date is the case a post-conversion guard would miss: it normalises to a
+	 * negative timestamp, and zeroBSCRM_locale_dateToUTS() falls back to strtotime(), which
+	 * reads a leading minus as a relative offset and returns roughly the current time.
+	 *
+	 * @testdox A pre-1970 date custom field survives the second pass without becoming today.
+	 */
+	#[TestDox( 'A pre-1970 date custom field survives the second pass without becoming today.' )]
+	public function test_pre_1970_date_custom_field_survives_second_pass() {
+		$expected = jpcrm_date_str_to_uts( '1950-01-01', '!Y-m-d', true );
+
+		$this->assertLessThan( 0, $expected, 'Fixture assumption: a 1950 date is a negative timestamp.' );
+
+		$result = $this->build_twice( array( 'contract-date' => '1950-01-01' ), ZBS_TYPE_CONTACT );
+
+		$this->assertSame( $expected, $result['contract-date'] );
+	}
+
+	/**
+	 * @testdox Normalising a date once and twice produce the same result.
+	 */
+	#[TestDox( 'Normalising a date once and twice produce the same result.' )]
+	public function test_normalising_twice_matches_normalising_once() {
+		$payload = array( 'contract-date' => '2026-07-23' );
+
+		$once  = zeroBS_buildObjArr( $payload, array(), '', '', true, ZBS_TYPE_CONTACT, false );
+		$twice = zeroBS_buildObjArr( $once, array(), '', '', true, ZBS_TYPE_CONTACT, false );
+
+		$this->assertSame( $once['contract-date'], $twice['contract-date'] );
+	}
+
+	/**
+	 * The pass-through accepts nine or more digits, so that a short numeric string is still
+	 * treated as an unparseable date rather than as a timestamp in 1970.
+	 *
+	 * @testdox A short numeric date value is not read as a timestamp.
+	 */
+	#[TestDox( 'A short numeric date value is not read as a timestamp.' )]
+	public function test_short_numeric_date_value_is_not_read_as_a_timestamp() {
+		$result = zeroBS_buildObjArr( array( 'contract-date' => '2026' ), array(), '', '', false, ZBS_TYPE_CONTACT, false );
+
+		$this->assertFalse( $result['contract-date'], 'A four digit year should still fail to parse, as it did before.' );
+	}
+
+	/**
+	 * @testdox Empty and unparseable date values behave as they did before.
+	 */
+	#[TestDox( 'Empty and unparseable date values behave as they did before.' )]
+	public function test_empty_and_unparseable_date_values_are_unchanged() {
+		foreach ( array( '', 'not-a-date' ) as $value ) {
+			$result = zeroBS_buildObjArr( array( 'contract-date' => $value ), array(), '', '', false, ZBS_TYPE_CONTACT, false );
+
+			$this->assertFalse( $result['contract-date'], sprintf( 'Expected %s to remain unparseable.', var_export( $value, true ) ) );
+		}
+	}
+}

--- a/tests/php/rest-api/API_Date_Custom_Field_Test.php
+++ b/tests/php/rest-api/API_Date_Custom_Field_Test.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Automattic\Jetpack\CRM\API\Tests;
+
+use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * End to end coverage for date custom fields sent to the legacy create/update API.
+ *
+ * The builder-level tests in tests/php/entities/Object_Array_Builder_Date_Test.php stop at
+ * zeroBS_buildObjArr(). These go the whole way: they run the same calls api/create_customer.php
+ * and api/create_company.php make, then read the record back out of the database and check the
+ * value actually landed in wp_zbs_customfields.
+ *
+ * @covers ::zeroBS_buildObjArr
+ */
+class API_Date_Custom_Field_Test extends JPCRM_Base_Integration_TestCase {
+
+	/**
+	 * Slug of the date custom field registered against contacts and companies.
+	 */
+	private const FIELD_SLUG = 'contract-date';
+
+	/**
+	 * The date as an API client would send it.
+	 */
+	private const DATE_STR = '2026-07-23';
+
+	/**
+	 * The same date as the DAL stores it.
+	 */
+	private const DATE_UTS = 1784764800;
+
+	/**
+	 * Register a real date custom field against contacts and companies, then rebuild the
+	 * field globals so the builder and the DAL both see it.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->register_custom_field(
+			self::FIELD_SLUG,
+			'date',
+			'Contract Date',
+			array(
+				'customers' => ZBS_TYPE_CONTACT,
+				'companies' => ZBS_TYPE_COMPANY,
+			)
+		);
+	}
+
+	/**
+	 * A date custom field sent to the contact create endpoint has to reach the database.
+	 *
+	 * Mirrors api/create_customer.php: build the payload with an empty input prefix and a
+	 * 'zbsc_' output prefix, then hand the result to zeroBS_integrations_addOrUpdateCustomer(),
+	 * which normalises it a second time inside zeroBS_addUpdateCustomer().
+	 *
+	 * @return void
+	 */
+	#[TestDox( 'A date custom field sent to the contact create API is stored.' )]
+	public function test_contact_create_api_stores_date_custom_field() {
+		global $zbs;
+
+		$email = 'date-api-contact@example.com';
+
+		$payload = array(
+			'email'          => $email,
+			'fname'          => 'Date',
+			'lname'          => 'Field',
+			self::FIELD_SLUG => self::DATE_STR,
+		);
+
+		// api/create_customer.php:51
+		$update_args = zeroBS_buildContactMeta( $payload, array(), '', 'zbsc_', false, true );
+
+		// api/create_customer.php:220
+		$contact_id = zeroBS_integrations_addOrUpdateCustomer( 'api', $email, $update_args );
+
+		$this->assertGreaterThan( 0, $contact_id, 'The contact was not created.' );
+
+		$contact = $zbs->DAL->contacts->getContact( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$contact_id,
+			array( 'withCustomFields' => true )
+		);
+
+		$this->assertArrayHasKey( self::FIELD_SLUG, $contact, 'The date custom field is missing from the contact.' );
+		$this->assertEquals(
+			self::DATE_UTS,
+			$contact[ self::FIELD_SLUG ],
+			'The date custom field did not reach the database.'
+		);
+	}
+
+	/**
+	 * The same, for the company create endpoint.
+	 *
+	 * Mirrors api/create_company.php, which calls zeroBS_buildObjArr() directly rather than
+	 * zeroBS_buildCompanyMeta(), and passes a 'zbsc_' prefix rather than 'zbsco_'.
+	 *
+	 * @return void
+	 */
+	#[TestDox( 'A date custom field sent to the company create API is stored.' )]
+	public function test_company_create_api_stores_date_custom_field() {
+		global $zbs;
+
+		$email = 'date-api-company@example.com';
+
+		$payload = array(
+			'email'          => $email,
+			'name'           => 'Date Field Ltd',
+			self::FIELD_SLUG => self::DATE_STR,
+		);
+
+		// api/create_company.php:30
+		$update_args = zeroBS_buildObjArr( $payload, array(), '', 'zbsc_', false, ZBS_TYPE_COMPANY, true );
+
+		// api/create_company.php:183
+		$company_id = zeroBS_integrations_addOrUpdateCompany( 'api', $email, $update_args, '', 'none', false, false, 'update', 'zbsc_' );
+
+		$this->assertGreaterThan( 0, $company_id, 'The company was not created.' );
+
+		$company = $zbs->DAL->companies->getCompany( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$company_id,
+			array( 'withCustomFields' => true )
+		);
+
+		$this->assertArrayHasKey( self::FIELD_SLUG, $company, 'The date custom field is missing from the company.' );
+		$this->assertEquals(
+			self::DATE_UTS,
+			$company[ self::FIELD_SLUG ],
+			'The date custom field did not reach the database.'
+		);
+	}
+}


### PR DESCRIPTION
Fixes #21

**Please don't merge this yet.** The tests pass, but there's an end-to-end check still outstanding, see the note at the end.

## What was broken

Send a date custom field to the contact or company create/update API and the value is silently thrown away. The contact is created, the response says success, and the custom field is simply missing. The response is misleading because the create endpoints echo the request payload back rather than the record that was saved. #22 covers that separately.

## Why

The payload gets normalised twice:

- `api/create_customer.php:51` calls `zeroBS_buildContactMeta()`, which turns `"2026-07-23"` into `1784764800`.
- That array goes to `zeroBS_addUpdateCustomer()`, which calls the builder again with `$removeEmpties` on.
- The second pass hits the same `date` branch, this time with a timestamp. `DateTime::createFromFormat( '!Y-m-d', '1784764800' )` fails, `jpcrm_date_str_to_uts()` returns `false`, and the empty-stripping at `ZeroBSCRM.DAL3.Helpers.php:3029` drops the key before it reaches the DAL.

`api/create_company.php` does the same thing. The admin UI is fine, it normalises once and goes straight to the DAL.

## The fix

The `date` and `datetime` branches of `zeroBS_buildObjArr()` now recognise an already-converted timestamp and pass it through, so normalising twice matches normalising once. New helper `jpcrm_value_is_uts()` does the check.

I left the double normalisation alone. `zeroBS_addUpdateCustomer()` is called by a lot of integrations that pass raw fields, so changing its contract is a much bigger job than making the conversion idempotent.

Two decisions worth a look:

**The rule for "this is already a timestamp"** is an int, or a string of nine or more digits with an optional leading minus. The digit floor is there because a bare `is_numeric()` would swallow short numeric strings: a date field submitted as `"2026"` would become a timestamp in 1970 instead of failing to parse the way it does today. Nine digits covers 1973 onwards, and the optional minus covers pre-1970 dates, which matters for birthday fields.

**The check runs before the conversion, not after.** I had it as a fallback on `false` first, which is the obvious shape, but it doesn't work for the `datetime` branch. `zeroBSCRM_locale_dateToUTS()` falls back to `strtotime()`, and `strtotime( '-631152000' )` doesn't fail, it reads the minus as a relative offset and returns roughly now:

```
php > date_default_timezone_set('UTC'); var_dump(date('Y-m-d H:i', strtotime('-631152000')));
string(16) "2026-07-29 21:51"
```

So a pre-1970 datetime would have quietly become today rather than being dropped. Checking first sidesteps that.

One behaviour change to be aware of: a date custom field submitted directly as `"1784764800"` used to be dropped and will now be stored as that timestamp. That seems right to me, it's the same value the read side hands back, but shout if you disagree.

## Tests

`tests/php/entities/Object_Array_Builder_Date_Test.php` covers the two-pass path for contacts and companies, date and datetime, the pre-1970 case, and that `"2026"`, empty and unparseable values still behave as they did.

All 50 tests across the four suites pass locally in wp-env on PHP 8.3:

```
OK (50 tests, 214 assertions)
```

I checked the new tests actually catch the bug rather than just passing alongside it. Reverting `includes/` to trunk and running them again fails 6 of the 8:

```
✘ A date custom field survives the second normalisation pass. with data set "contact"
  The date custom field was stripped before reaching the DAL.
✘ A pre-1970 date custom field survives the second pass without becoming today.
  Failed asserting that null is identical to -631152000.
...
Tests: 8, Assertions: 12, Failures: 6
```

The two that still pass with the fix reverted are the "behaviour unchanged" ones, which is what you'd want.

There's no PHPUnit workflow in `.github/workflows/`, so nothing runs these on the PR. `phpcs` isn't installed locally so the lint didn't run either.

## Still to do

- End-to-end check against a real site: create a contact through the API with a date custom field, then confirm the row in `wp_zbs_customfields` and the value in the admin UI. The tests here stop at the builder, so that's the gap.
- Confirm the admin UI create/edit path still saves date custom fields. It normalises once so it should be untouched, but I haven't clicked through it.

Leaving this as a draft until that end-to-end check is done. `zeroBS_buildObjArr()` is the shared normaliser for contacts, companies, transactions, invoices, quotes and tasks, across the admin UI, API, forms and imports, so it's worth confirming on a real site before it goes anywhere near a release. Happy for someone else to do that check and take it off draft if it's urgent.

Reported by @alllexandrz.
