### PR TITLE
Fix partial customer updates in legacy API

### DIFF
--- a/api/create_customer.php
+++ b/api/create_customer.php
@@ -15,7 +15,6 @@ global $zbs;
 $json_params  = file_get_contents( 'php://input' );
 $new_customer = json_decode( $json_params, true );
 
-// if this isn't an array, reply NO
 if ( ! is_array( $new_customer ) ) {
 	wp_send_json(
 		array(
@@ -27,93 +26,64 @@ if ( ! is_array( $new_customer ) ) {
 	);
 }
 
-// no tags assumption, etc.
-$we_have_tags = false;
-$contact_id   = -1;
-$email        = '';
+$contact_id   = isset( $new_customer['id'] ) ? (int) $new_customer['id'] : -1;
+$email        = isset( $new_customer['email'] ) ? sanitize_text_field( $new_customer['email'] ) : '';
+$assign       = isset( $new_customer['assign'] ) ? (int) $new_customer['assign'] : -1;
+$sticky       = empty( $new_customer['sticky'] );
+$sticky_stat  = isset( $new_customer['stickystat'] ) ? sanitize_text_field( $new_customer['stickystat'] ) : 'Customer';
+$contact_tags = jpcrm_api_sanitize_tags( $new_customer['tags'] ?? false );
 
-// pass sticky status - pass sticky = false to not have a sticky status
-$sticky = true;
-if ( isset( $new_customer['sticky'] ) && ! empty( $new_customer['sticky'] ) ) {
-	$sticky = false;
+// Resolve the contact before preparing fields so omitted values can be preserved.
+$existing_id = -1;
+if ( $contact_id > 0 ) {
+	$existing_id = (int) $zbs->DAL->contacts->getContact( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$contact_id,
+		array(
+			'withCustomFields' => false,
+			'ignoreowner'      => true,
+			'onlyID'           => true,
+		)
+	);
 }
-$stickystat = 'Customer';
-if ( isset( $new_customer['stickystat'] ) ) {
-	$stickystat = sanitize_text_field( $new_customer['stickystat'] );
-}
-
-// this retrieves all fields (inc CUSTOM FIELDS) into customer_array
-// empty prefix important here
-$remove_empties      = false;
-$autogen_autonumbers = true;
-// setting $autoGenAutonumbers = true, means if they're not passed, they'll get generated
-// autoGenAutonumbers is duck-tape for now, rethink input + field model v3.0+
-$customer_array = zeroBS_buildContactMeta( $new_customer, array(), '', 'zbsc_', $remove_empties, $autogen_autonumbers );
-
-// this is needed for check below:
-if ( isset( $new_customer['id'] ) ) {
-	$contact_id = (int) $new_customer['id'];
-}
-if ( isset( $customer_array['zbsc_email'] ) ) {
-	$email = $customer_array['zbsc_email'];
+if ( $existing_id < 1 && ! empty( $email ) && zeroBSCRM_validateEmail( $email ) ) {
+	$existing_id = (int) zeroBS_getCustomerIDWithEmail( $email );
 }
 
-// diff name used below :)
-$update_args = $customer_array;
-
-// } Owner
-$assign = -1;
-if ( isset( $new_customer['assign'] ) ) {
-	$assign = (int) $new_customer['assign'];
+$existing_contact = false;
+if ( $existing_id > 0 ) {
+	$existing_contact = $zbs->DAL->contacts->getContact(
+		$existing_id,
+		array(
+			'ignoreowner' => true,
+		)
+	);
 }
 
-// } TAGS
-$tags = false;
-if ( isset( $new_customer['tags'] ) ) {
-	$tags = $new_customer['tags'];
-}
-if ( is_array( $tags ) && count( $tags ) > 0 ) {
-
-	// basic filtering
-	$customer_tags = filter_var_array( $tags, FILTER_UNSAFE_RAW );
-	// Formerly this used FILTER_SANITIZE_STRING, which is now deprecated as it was fairly broken. This is basically equivalent.
-	// @todo Replace this with something more correct.
-	foreach ( $customer_tags as $k => $v ) {
-		$customer_tags[ $k ] = strtr(
-			wp_strip_all_tags( $v ),
-			array(
-				"\0" => '',
-				'"'  => '&#34;',
-				"'"  => '&#39;',
-				'<'  => '',
-			)
-		);
-	}
-
-	// dumb check - not empties :)
-	$temptags = array(); foreach ( $customer_tags as $t ) {
-		$t2 = trim( $t );
-		if ( ! empty( $t2 ) ) {
-			$temptags[] = $t2;
-		}
-	}
-
-	// last check + set
-	if ( count( $temptags ) > 0 ) {
-		$we_have_tags  = true;
-		$customer_tags = $temptags;
-		unset( $temptags );
-	}
+$update_args = jpcrm_api_prepare_contact_fields( $new_customer, $existing_contact );
+if ( $existing_id > 0 ) {
+	$update_args['id'] = $existing_id;
 }
 
-// } Build pretty log msgs :)
+$email = isset( $update_args['zbsc_email'] ) ? sanitize_text_field( $update_args['zbsc_email'] ) : '';
 
-// } DEFAULTS
-// } Existing user updated by API
+// Preserve a sticky status, otherwise only default status for a new contact.
+if ( $existing_id > 0 && $sticky && is_array( $existing_contact ) && $sticky_stat === $existing_contact['status'] ) {
+	$update_args['zbsc_status'] = $sticky_stat;
+} elseif ( $existing_id < 1 && empty( $update_args['zbsc_status'] ) ) {
+	$update_args['zbsc_status'] = zeroBSCRM_getSetting( 'defaultstatus' );
+}
+
+if ( ! empty( $contact_tags ) ) {
+	$update_args['tags'] = $contact_tags;
+}
+
+// The integration's full-row update resets ownership, so restore it when omitted.
+if ( ! array_key_exists( 'assign', $new_customer ) && is_array( $existing_contact ) && isset( $existing_contact['owner'] ) ) {
+	$assign = (int) $existing_contact['owner'];
+}
+
 $existing_user_api_source_short = __( 'Updated by API Action', 'zero-bs-crm' ) . ' <i class="fa fa-random"></i>';
 $existing_user_api_source_long  = __( 'API Action fired to update contact', 'zero-bs-crm' );
-
-// } New User from API
 $new_user_api_source_short = __( 'Created from API Action', 'zero-bs-crm' ) . ' <i class="fa fa-random"></i>';
 $new_user_api_source_long  = __( 'API Action fired to create contact', 'zero-bs-crm' );
 
@@ -141,14 +111,12 @@ if ( $external_api_name !== false ) {
 	);
 }
 
-// } Actual log var passed
 $fallback_log = array(
 	'type'      => 'API Action',
 	'shortdesc' => $existing_user_api_source_short,
 	'longdesc'  => $existing_user_api_source_long,
 );
 
-// } Internal automator overrides - here we pass a "customer.create" note override (so we can pass it a custom str, else we let it fall back to "created by api")
 $internal_automator_override = array(
 	'note_override' => array(
 		'type'      => 'API Action',
@@ -157,110 +125,31 @@ $internal_automator_override = array(
 	),
 );
 
-// } Validate ID if passed
-$verified_id = -1;
-if ( $contact_id > 0 ) {
-	$verified_id = $zbs->DAL->contacts->getContact( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		$contact_id,
-		array(
-			'withCustomFields' => false,
-			'ignoreowner'      => true,
-			'onlyID'           => true,
-		)
-	);
-}
-
-// } EMAIL or ID :)
-if (
-	( ! empty( $email ) && zeroBSCRM_validateEmail( $email ) )
-	||
-	$verified_id > 0
-) {
-
-	// } STICKY status addition - dont have the API update our status if it's sticky
-	// } added if ID, exists 12/04/18
-	if ( $verified_id < 1 ) {
-		$exists = zeroBS_getCustomerIDWithEmail( $email );
-	} else {
-		$exists            = $verified_id;
-		$update_args['id'] = $verified_id;
-	}
-
-	if ( $exists && $sticky ) {
-
-		// email exists, chechk status
-		$existing_status = $zbs->DAL->contacts->getContactStatus( $exists ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-
-		if ( $existing_status === $stickystat ) {
-				// so.... set it to be the stickystat/it's existing
-				$update_args['zbsc_status'] = $stickystat; // 'Customer';
-		} else { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedElse
-			// existing status (e.g. lead) is not stickystatus (e.g. customer)
-			// so let it override default
-		}
-	}
-
-	// } Status default - double-backup for api check
-	if ( isset( $update_args ) && is_array( $update_args ) && ( $update_args['zbsc_status'] === null || ! isset( $update_args['zbsc_status'] ) || empty( $update_args['zbsc_status'] ) ) ) {
-		$default_status             = zeroBSCRM_getSetting( 'defaultstatus' );
-		$update_args['zbsc_status'] = $default_status; // 'Lead';
-	}
-
-	if ( $we_have_tags ) {
-		$update_args['tags'] = $customer_tags;
-	}
-
-	/**
-	 * Need to pass via the update_args otherwise the tags are added AFTER the automation fires...      when doing new DB we need to hook and filter up varios steps of these
-	 * e.g.
-	 * apply_filters('pre_do_this', $args);
-	 * ...do_this...
-	 * apply_filters('post_do_this', $args);
-	 */
+$valid_email = ! empty( $email ) && zeroBSCRM_validateEmail( $email );
+if ( $valid_email || $existing_id > 0 ) {
+	// The integration requires an external ID even when the contact was found by ID.
+	$external_id = $valid_email ? $email : (string) $existing_id;
 	$new_contact = zeroBS_integrations_addOrUpdateCustomer(
 		'api',
-		$email,
+		$external_id,
 		$update_args,
-		'', // ) Customer date (auto)
-		// } Fallback log (for customers who already exist)
+		'',
 		$fallback_log,
-		false, // } Extra meta
-		// } Internal automator overrides - here we pass a "customer.create" note override (so we can pass it a custom str, else we let it fall back to "created by API")
+		false,
 		$internal_automator_override
 	);
-	// ^^ this'll be either: ID if added, no of rows if updated, or FALSE if failed to insert/update
 
-	// } This makes our new customer trigger fire... without this, it isn't firing now ???
-	// dig deeper since zeroBS_integrations_addOrUpdateCustomer should fire this..
-	// do_action('zbs_new_customer', $new_contact);
-
-	// } are we assigning to a user?
-	if ( ! empty( $assign ) && $assign > -1 ) {
-		// set owner
+	if ( $new_contact > 0 && $assign > 0 ) {
 		zeroBS_setOwner( $new_contact, $assign, ZBS_TYPE_CONTACT );
 	}
 
-	// thorough much? lol.
-	if ( ! empty( $new_contact ) && $new_contact !== -1 ) {
-
-		// return what was passed...
-		// this is legacy funk.. not ideal at all, should probs reload.
+	if ( $new_contact > 0 ) {
 		$return_params = $new_customer;
-
-		// add id if new
-		if ( $new_contact > 0 ) {
-			$return_params['id'] = $new_contact;
-		}
-
-		// return
+		$return_params['id'] = $new_contact;
 		wp_send_json( $return_params, 200, JSON_UNESCAPED_SLASHES );
-
-	} else {
-
-		// fail.
-		wp_send_json( array( 'error' => 100 ), 200, JSON_UNESCAPED_SLASHES );
-
 	}
+
+	wp_send_json( array( 'error' => 100 ), 200, JSON_UNESCAPED_SLASHES );
 }
 
 wp_send_json( array( 'errors' => 1 ), 200, JSON_UNESCAPED_SLASHES );

--- a/includes/ZeroBSCRM.API.php
+++ b/includes/ZeroBSCRM.API.php
@@ -77,6 +77,80 @@ function jpcrm_api_process_external_api_name() {
 }
 
 /**
+ * Prepare contact fields from an API payload.
+ *
+ * Existing values are included for updates because the legacy contact integration
+ * performs a full-row update. This gives the endpoint PATCH-like semantics: a
+ * field is only changed when it is present in the payload.
+ *
+ * @param array      $payload          Decoded request payload.
+ * @param array|false $existing_contact Existing contact, or false for a new contact.
+ * @return array Contact fields using the prefix expected by the integration layer.
+ */
+function jpcrm_api_prepare_contact_fields( $payload, $existing_contact = false ) {
+	global $zbs, $zbsCustomerFields;
+
+	$contact_model    = $zbs->DAL->contacts->objModel(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	$supported_fields = $zbsCustomerFields;
+
+	// Continue accepting the pre-DAL3 second-address field names.
+	foreach ( $contact_model as $field_key => $field ) {
+		if ( isset( $field['dal1key'] ) && array_key_exists( $field['dal1key'], $payload ) && ! array_key_exists( $field_key, $payload ) ) {
+			$payload[ $field_key ] = $payload[ $field['dal1key'] ];
+		}
+	}
+
+	// These non-form fields are writable by the legacy endpoint and full-row DAL update.
+	foreach ( array( 'wpid', 'avatar', 'tw', 'fb', 'li' ) as $field_key ) {
+		if ( isset( $contact_model[ $field_key ] ) ) {
+			$supported_fields[ $field_key ] = $contact_model[ $field_key ];
+		}
+	}
+
+	$contact_fields = array();
+	$is_update      = is_array( $existing_contact );
+
+	foreach ( $supported_fields as $field_key => $field ) {
+		if ( array_key_exists( $field_key, $payload ) ) {
+			$contact_fields[ 'zbsc_' . $field_key ] = $payload[ $field_key ];
+		} elseif ( $is_update && array_key_exists( $field_key, $existing_contact ) ) {
+			$contact_fields[ 'zbsc_' . $field_key ] = $existing_contact[ $field_key ];
+		} elseif ( ! $is_update && isset( $field[0] ) && 'autonumber' === $field[0] ) {
+			// A blank value tells the integration layer to generate the autonumber.
+			$contact_fields[ 'zbsc_' . $field_key ] = '';
+		}
+	}
+
+	return $contact_fields;
+}
+
+/**
+ * Sanitize a list of tag names received by the API.
+ *
+ * @param mixed $tags Potential list of tag names.
+ * @return array Sanitized, non-empty tag names.
+ */
+function jpcrm_api_sanitize_tags( $tags ) {
+	if ( ! is_array( $tags ) ) {
+		return array();
+	}
+
+	$sanitized_tags = array();
+	foreach ( $tags as $tag ) {
+		if ( ! is_scalar( $tag ) ) {
+			continue;
+		}
+
+		$tag = trim( sanitize_text_field( (string) $tag ) );
+		if ( '' !== $tag ) {
+			$sanitized_tags[] = $tag;
+		}
+	}
+
+	return $sanitized_tags;
+}
+
+/**
  * Generate API invalid request error
  */
 function jpcrm_api_invalid_request() {

--- a/tests/php/rest-api/API_Create_Customer_Fields_Test.php
+++ b/tests/php/rest-api/API_Create_Customer_Fields_Test.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Automattic\Jetpack\CRM\API\Tests;
+
+use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Tests for the legacy create_customer endpoint field preparation.
+ */
+class API_Create_Customer_Fields_Test extends JPCRM_Base_Integration_TestCase {
+
+	/**
+	 * Ensure partial API updates preserve fields omitted from the payload.
+	 */
+	#[TestDox( 'Partial customer updates preserve omitted fields and allow explicit clears.' )]
+	public function test_partial_update_preserves_omitted_fields() {
+		global $zbs;
+
+		$contact_id = $this->add_contact(
+			array(
+				'email'   => 'partial-update@example.com',
+				'fname'   => 'Original',
+				'lname'   => 'Preserved',
+				'addr1'   => '123 Existing Street',
+				'worktel' => '01234 567890',
+				'tw'      => 'preserved-social-handle',
+			)
+		);
+
+		$existing_contact = $zbs->DAL->contacts->getContact( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$contact_id,
+			array( 'ignoreowner' => true )
+		);
+		$update_args       = jpcrm_api_prepare_contact_fields(
+			array(
+				'fname'   => 'Updated',
+				'worktel' => '',
+			),
+			$existing_contact
+		);
+		$update_args['id'] = $contact_id;
+
+		$result = zeroBS_integrations_addOrUpdateCustomer(
+			'api',
+			'partial-update@example.com',
+			$update_args
+		);
+
+		$this->assertSame( $contact_id, $result );
+
+		$updated_contact = $zbs->DAL->contacts->getContact( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$contact_id,
+			array( 'ignoreowner' => true )
+		);
+
+		$this->assertSame( 'Updated', $updated_contact['fname'] );
+		$this->assertSame( '', $updated_contact['worktel'] );
+		$this->assertSame( 'Preserved', $updated_contact['lname'] );
+		$this->assertSame( '123 Existing Street', $updated_contact['addr1'] );
+		$this->assertSame( 'preserved-social-handle', $updated_contact['tw'] );
+	}
+}


### PR DESCRIPTION
## Summary

- simplify the legacy `create_customer` endpoint and remove its direct `zeroBS_buildContactMeta()` call
- preserve omitted contact, custom, social, and ownership fields during partial updates
- keep explicit standard-field clears, sticky statuses, tags, legacy second-address keys, and autonumber generation working
- add regression coverage for partial customer updates

## Testing

- `php -l api/create_customer.php`
- `php -l includes/ZeroBSCRM.API.php`
- `php -l tests/php/rest-api/API_Create_Customer_Fields_Test.php`
- standalone field-preparation assertions
- PHPUnit integration test added but not run locally because the WordPress test library is not installed/configured