### PR TITLE
Check view permissions for every list view type

### DIFF
--- a/includes/ZeroBSCRM.AJAX.php
+++ b/includes/ZeroBSCRM.AJAX.php
@@ -2085,25 +2085,7 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 		global $zbs;
 
 		// } check perms first
-		if ( $listViewParams['listtype'] == 'customer' && ! zeroBSCRM_permsViewCustomers() ) {
-			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
-		}
-		if ( $listViewParams['listtype'] == 'company' && ! zeroBSCRM_permsViewCustomers() ) {
-			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
-		}
-		if ( $listViewParams['listtype'] == 'segment' && ! zeroBSCRM_permsViewCustomers() ) {
-			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
-		}
-		if ( $listViewParams['listtype'] == 'quote' && ! zeroBSCRM_permsViewQuotes() ) {
-			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
-		}
-		if ( $listViewParams['listtype'] == 'quotetemplate' && ! zeroBSCRM_permsViewQuotes() ) {
-			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
-		}
-		if ( $listViewParams['listtype'] == 'invoice' && ! zeroBSCRM_permsViewInvoices() ) {
-			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
-		}
-		if ( $listViewParams['listtype'] == 'transaction' && ! zeroBSCRM_permsViewTransactions() ) {
+		if ( ! jpcrm_perms_view_list_type( $listViewParams['listtype'] ) ) {
 			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 		}
 

--- a/includes/ZeroBSCRM.AJAX.php
+++ b/includes/ZeroBSCRM.AJAX.php
@@ -2085,7 +2085,7 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 		global $zbs;
 
 		// } check perms first
-		if ( ! jpcrm_perms_view_list_type( $listViewParams['listtype'] ) ) {
+		if ( ! jpcrm_perms_view_list_type( $listViewParams['listtype'] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 		}
 

--- a/includes/ZeroBSCRM.Permissions.php
+++ b/includes/ZeroBSCRM.Permissions.php
@@ -607,8 +607,9 @@ function zeroBSCRM_permsObjType( $obj_type_id = -1 ) { // phpcs:ignore WordPress
  *
  * Types we do not serve ourselves are handled by extensions, which hook
  * `zerobs_ajax_list_view_{$list_type}` in the list view handler. Those are
- * allowed through to any CRM back end user, and the extension applies its own
- * check. Anything with no listener is denied.
+ * allowed through to any CRM back end user, on the expectation that the
+ * extension applies its own check, either in the hook or through the
+ * `jpcrm_perms_view_list_type` filter below. Anything with no listener is denied.
  *
  * @param string $list_type List view type, as used by zeroBSCRM_list (e.g. 'customer', 'event').
  *
@@ -806,6 +807,14 @@ function zeroBSCRM_permsForms() {
 	return false;
 }
 
+/**
+ * Determine if the current user is allowed to edit tasks (events).
+ *
+ * This is the edit capability. For the task list views, use
+ * jpcrm_perms_view_tasks() below, which matches what the pages register.
+ *
+ * @return bool
+ */
 function zeroBSCRM_perms_tasks() {
 
 	$cu = wp_get_current_user();

--- a/includes/ZeroBSCRM.Permissions.php
+++ b/includes/ZeroBSCRM.Permissions.php
@@ -600,8 +600,15 @@ function zeroBSCRM_permsObjType( $obj_type_id = -1 ) { // phpcs:ignore WordPress
 /**
  * Determine if the current user is allowed to view a given list view type.
  *
- * The list view type is supplied by the client, so every supported type needs
- * an explicit view capability here. Anything unrecognised is denied.
+ * The list view type is supplied by the client, so every type we serve needs an
+ * explicit view capability here. The capabilities are kept in step with what the
+ * matching admin page registers in ZeroBSCRM.Core.Menus.WP.php, which is the
+ * source of truth for who can reach each list.
+ *
+ * Types we do not serve ourselves are handled by extensions, which hook
+ * `zerobs_ajax_list_view_{$list_type}` in the list view handler. Those are
+ * allowed through to any CRM back end user, and the extension applies its own
+ * check. Anything with no listener is denied.
  *
  * @param string $list_type List view type, as used by zeroBSCRM_list (e.g. 'customer', 'event').
  *
@@ -632,6 +639,22 @@ function jpcrm_perms_view_list_type( $list_type ) {
 		case 'form':
 			return zeroBSCRM_permsForms();
 
+	}
+
+	// Not one of ours. Only let it through if an extension is listening for it.
+	if ( ! empty( $list_type ) && has_action( 'zerobs_ajax_list_view_' . $list_type ) ) {
+
+		/**
+		 * Filters whether the current user may view an extension supplied list view type.
+		 *
+		 * Only fires for list types Jetpack CRM does not serve itself. Extensions
+		 * registering `zerobs_ajax_list_view_{$list_type}` should use this to apply
+		 * their own capability check, rather than relying on the default.
+		 *
+		 * @param bool   $allowed   Whether the user may view this list type.
+		 * @param string $list_type The list view type requested.
+		 */
+		return (bool) apply_filters( 'jpcrm_perms_view_list_type', zeroBSCRM_permsIsZBSBackendUser(), $list_type );
 	}
 
 	return false;

--- a/includes/ZeroBSCRM.Permissions.php
+++ b/includes/ZeroBSCRM.Permissions.php
@@ -598,6 +598,46 @@ function zeroBSCRM_permsObjType( $obj_type_id = -1 ) { // phpcs:ignore WordPress
 }
 
 /**
+ * Determine if the current user is allowed to view a given list view type.
+ *
+ * The list view type is supplied by the client, so every supported type needs
+ * an explicit view capability here. Anything unrecognised is denied.
+ *
+ * @param string $list_type List view type, as used by zeroBSCRM_list (e.g. 'customer', 'event').
+ *
+ * @return bool
+ */
+function jpcrm_perms_view_list_type( $list_type ) {
+
+	switch ( $list_type ) {
+
+		case 'customer':
+		case 'company':
+		case 'segment':
+			return zeroBSCRM_permsViewCustomers();
+
+		case 'quote':
+		case 'quotetemplate':
+			return zeroBSCRM_permsViewQuotes();
+
+		case 'invoice':
+			return zeroBSCRM_permsViewInvoices();
+
+		case 'transaction':
+			return zeroBSCRM_permsViewTransactions();
+
+		case 'event':
+			return jpcrm_perms_view_tasks();
+
+		case 'form':
+			return zeroBSCRM_permsForms();
+
+	}
+
+	return false;
+}
+
+/**
  * Determine if a user is allowed to manage contacts.
  *
  * @since 6.1.0
@@ -751,6 +791,21 @@ function zeroBSCRM_perms_tasks() {
 	}
 	return false;
 }
+
+/**
+ * Determine if the current user is allowed to view tasks (events).
+ *
+ * This mirrors the capability used by the Task Scheduler and Task List admin
+ * pages, which is separate from the task edit capability.
+ *
+ * @return bool
+ */
+function jpcrm_perms_view_tasks() {
+
+	$cu = wp_get_current_user();
+	return $cu->has_cap( 'admin_zerobs_view_events' );
+}
+
 function zeroBSCRM_permsNotify() {
 
 	$cu = wp_get_current_user();

--- a/includes/ZeroBSCRM.Permissions.php
+++ b/includes/ZeroBSCRM.Permissions.php
@@ -623,44 +623,51 @@ function jpcrm_perms_view_list_type( $list_type ) {
 		case 'customer':
 		case 'company':
 		case 'segment':
-			return zeroBSCRM_permsViewCustomers();
+			$allowed = zeroBSCRM_permsViewCustomers();
+			break;
 
 		case 'quote':
 		case 'quotetemplate':
-			return zeroBSCRM_permsViewQuotes();
+			$allowed = zeroBSCRM_permsViewQuotes();
+			break;
 
 		case 'invoice':
-			return zeroBSCRM_permsViewInvoices();
+			$allowed = zeroBSCRM_permsViewInvoices();
+			break;
 
 		case 'transaction':
-			return zeroBSCRM_permsViewTransactions();
+			$allowed = zeroBSCRM_permsViewTransactions();
+			break;
 
 		case 'event':
-			return jpcrm_perms_view_tasks();
+			$allowed = jpcrm_perms_view_tasks();
+			break;
 
 		case 'form':
-			return zeroBSCRM_permsForms();
+			$allowed = zeroBSCRM_permsForms();
+			break;
+
+		default:
+			// Not one of ours. Only let it through if an extension is listening for it.
+			$allowed = ! empty( $list_type )
+				&& has_action( 'zerobs_ajax_list_view_' . $list_type )
+				&& zeroBSCRM_permsIsZBSBackendUser();
+			break;
 
 	}
 
-	// Not one of ours. Only let it through if an extension is listening for it.
-	if ( ! empty( $list_type ) && has_action( 'zerobs_ajax_list_view_' . $list_type ) ) {
-
-		/**
-		 * Filters whether the current user may view an extension supplied list view type.
-		 *
-		 * Only fires for list types Jetpack CRM does not serve itself. An extension
-		 * registering `zerobs_ajax_list_view_{$list_type}` is responsible for the
-		 * capability check for that list view, and can apply it here instead of in
-		 * its hook callback.
-		 *
-		 * @param bool   $allowed   Whether the user may view this list type.
-		 * @param string $list_type The list view type requested.
-		 */
-		return (bool) apply_filters( 'jpcrm_perms_view_list_type', zeroBSCRM_permsIsZBSBackendUser(), $list_type );
-	}
-
-	return false;
+	/**
+	 * Filters whether the current user may view a given list view type.
+	 *
+	 * Fires for every list type, ours and those supplied by extensions, so a site
+	 * can widen or narrow access to any list view. An extension registering
+	 * `zerobs_ajax_list_view_{$list_type}` is responsible for the capability check
+	 * for that list view, and can apply it here instead of in its hook callback.
+	 *
+	 * @param bool   $allowed   Whether the user may view this list type.
+	 * @param string $list_type The list view type requested.
+	 */
+	return (bool) apply_filters( 'jpcrm_perms_view_list_type', (bool) $allowed, $list_type );
 }
 
 /**

--- a/includes/ZeroBSCRM.Permissions.php
+++ b/includes/ZeroBSCRM.Permissions.php
@@ -612,6 +612,8 @@ function zeroBSCRM_permsObjType( $obj_type_id = -1 ) { // phpcs:ignore WordPress
  * through the `jpcrm_perms_view_list_type` filter below. Anything with no
  * listener is denied.
  *
+ * @since $$next-version$$
+ *
  * @param string $list_type List view type, as used by zeroBSCRM_list (e.g. 'customer', 'event').
  *
  * @return bool
@@ -663,6 +665,8 @@ function jpcrm_perms_view_list_type( $list_type ) {
 	 * can widen or narrow access to any list view. An extension registering
 	 * `zerobs_ajax_list_view_{$list_type}` is responsible for the capability check
 	 * for that list view, and can apply it here instead of in its hook callback.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @param bool   $allowed   Whether the user may view this list type.
 	 * @param string $list_type The list view type requested.
@@ -838,6 +842,8 @@ function zeroBSCRM_perms_tasks() {
  *
  * This mirrors the capability used by the Task Scheduler and Task List admin
  * pages, which is separate from the task edit capability.
+ *
+ * @since $$next-version$$
  *
  * @return bool
  */

--- a/includes/ZeroBSCRM.Permissions.php
+++ b/includes/ZeroBSCRM.Permissions.php
@@ -606,10 +606,11 @@ function zeroBSCRM_permsObjType( $obj_type_id = -1 ) { // phpcs:ignore WordPress
  * source of truth for who can reach each list.
  *
  * Types we do not serve ourselves are handled by extensions, which hook
- * `zerobs_ajax_list_view_{$list_type}` in the list view handler. Those are
- * allowed through to any CRM back end user, on the expectation that the
- * extension applies its own check, either in the hook or through the
- * `jpcrm_perms_view_list_type` filter below. Anything with no listener is denied.
+ * `zerobs_ajax_list_view_{$list_type}` in the list view handler. Those reach the
+ * extension as they did before, and the extension is responsible for the
+ * capability check for the list views it serves, either in its hook callback or
+ * through the `jpcrm_perms_view_list_type` filter below. Anything with no
+ * listener is denied.
  *
  * @param string $list_type List view type, as used by zeroBSCRM_list (e.g. 'customer', 'event').
  *
@@ -648,9 +649,10 @@ function jpcrm_perms_view_list_type( $list_type ) {
 		/**
 		 * Filters whether the current user may view an extension supplied list view type.
 		 *
-		 * Only fires for list types Jetpack CRM does not serve itself. Extensions
-		 * registering `zerobs_ajax_list_view_{$list_type}` should use this to apply
-		 * their own capability check, rather than relying on the default.
+		 * Only fires for list types Jetpack CRM does not serve itself. An extension
+		 * registering `zerobs_ajax_list_view_{$list_type}` is responsible for the
+		 * capability check for that list view, and can apply it here instead of in
+		 * its hook callback.
 		 *
 		 * @param bool   $allowed   Whether the user may view this list type.
 		 * @param string $list_type The list view type requested.

--- a/includes/ZeroBSCRM.Permissions.php
+++ b/includes/ZeroBSCRM.Permissions.php
@@ -607,10 +607,11 @@ function zeroBSCRM_permsObjType( $obj_type_id = -1 ) { // phpcs:ignore WordPress
  *
  * Types we do not serve ourselves are handled by extensions, which hook
  * `zerobs_ajax_list_view_{$list_type}` in the list view handler. Those reach the
- * extension as they did before, and the extension is responsible for the
- * capability check for the list views it serves, either in its hook callback or
- * through the `jpcrm_perms_view_list_type` filter below. Anything with no
- * listener is denied.
+ * extension if a CRM backend user asked for them, and the extension is
+ * responsible for the capability check for the list views it serves, either in
+ * its hook callback or through the `jpcrm_perms_view_list_type` filter below.
+ * Anything with no listener is denied, as is anything asked for by someone with
+ * no CRM access at all.
  *
  * @since $$next-version$$
  *
@@ -650,7 +651,8 @@ function jpcrm_perms_view_list_type( $list_type ) {
 			break;
 
 		default:
-			// Not one of ours. Only let it through if an extension is listening for it.
+			// Not one of ours. Only let it through if an extension is listening for
+			// it, and then only for a user with CRM access.
 			$allowed = ! empty( $list_type )
 				&& has_action( 'zerobs_ajax_list_view_' . $list_type )
 				&& zeroBSCRM_permsIsZBSBackendUser();
@@ -665,13 +667,15 @@ function jpcrm_perms_view_list_type( $list_type ) {
 	 * can widen or narrow access to any list view. An extension registering
 	 * `zerobs_ajax_list_view_{$list_type}` is responsible for the capability check
 	 * for that list view, and can apply it here instead of in its hook callback.
+	 * Note that an extension type only reaches this filter as `true` for a user
+	 * who already has CRM backend access.
 	 *
 	 * @since $$next-version$$
 	 *
 	 * @param bool   $allowed   Whether the user may view this list type.
 	 * @param string $list_type The list view type requested.
 	 */
-	return (bool) apply_filters( 'jpcrm_perms_view_list_type', (bool) $allowed, $list_type );
+	return (bool) apply_filters( 'jpcrm_perms_view_list_type', $allowed, $list_type );
 }
 
 /**

--- a/phpunit.11.xml.dist
+++ b/phpunit.11.xml.dist
@@ -31,6 +31,9 @@
 		<testsuite name="pdf">
 			<directory suffix="Test.php">tests/php/pdf</directory>
 		</testsuite>
+		<testsuite name="permissions">
+			<directory suffix="Test.php">tests/php/permissions</directory>
+		</testsuite>
 	</testsuites>
 
 	<source>

--- a/phpunit.9.xml.dist
+++ b/phpunit.9.xml.dist
@@ -22,5 +22,8 @@
 		<testsuite name="pdf">
 			<directory suffix="Test.php">tests/php/pdf</directory>
 		</testsuite>
+		<testsuite name="permissions">
+			<directory suffix="Test.php">tests/php/permissions</directory>
+		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/php/permissions/List_View_Ajax_Permissions_Test.php
+++ b/tests/php/permissions/List_View_Ajax_Permissions_Test.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Tests for the list view data AJAX endpoint permission checks.
+ *
+ * @package Automattic\Jetpack\CRM
+ */
+
+namespace Automattic\Jetpack\CRM\Tests;
+
+use PHPUnit\Framework\Attributes\TestDox;
+use WP_Ajax_UnitTestCase;
+use WPAjaxDieContinueException;
+
+/**
+ * Test that the list view data endpoint honours per-object view capabilities.
+ *
+ * Deliberately not in the `ajax` group: the WordPress test harness skips that
+ * group by convention, and these are regression tests that must always run.
+ */
+class List_View_Ajax_Permissions_Test extends WP_Ajax_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Sign in as a user holding the given capabilities and prime the AJAX request.
+	 *
+	 * @param array  $caps      Capabilities to grant.
+	 * @param string $list_type List view type to request.
+	 *
+	 * @return void
+	 */
+	private function prepare_request( array $caps, $list_type ) {
+
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$user    = get_user_by( 'id', $user_id );
+
+		foreach ( $caps as $cap ) {
+			$user->add_cap( $cap );
+		}
+
+		wp_set_current_user( $user_id );
+
+		$_POST = array(
+			'action' => 'retrieveListViewData',
+			'sec'    => wp_create_nonce( 'zbscrmjs-ajax-nonce' ),
+			'v'      => array(
+				'listtype' => $list_type,
+				'count'    => 20,
+				'paged'    => 1,
+			),
+		);
+	}
+
+	/**
+	 * Run the endpoint and return the decoded response.
+	 *
+	 * @return array
+	 */
+	private function fetch_list_view() {
+
+		// admin_init sends admin headers, and PHPUnit has already written to stdout
+		// by the time the test runs, so PHP warns that headers were already sent.
+		// That is an artefact of running admin AJAX under the CLI test harness, so
+		// swallow just that warning and leave every other error to PHPUnit.
+		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+			static function ( $errno, $errstr ) {
+				return str_contains( $errstr, 'Cannot modify header information' );
+			},
+			E_WARNING
+		);
+
+		try {
+			$this->_handleAjax( 'retrieveListViewData' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			unset( $e );
+		} finally {
+			restore_error_handler();
+		}
+
+		return json_decode( $this->_last_response, true );
+	}
+
+	/**
+	 * Assert that the endpoint refused the request on permission grounds.
+	 *
+	 * @param array $response Decoded endpoint response.
+	 *
+	 * @return void
+	 */
+	private function assert_refused( $response ) {
+
+		$this->assertArrayHasKey( 'success', $response );
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 1, $response['data']['no-action-or-rights'] );
+	}
+
+	/**
+	 * Clean up request state.
+	 *
+	 * @return void
+	 */
+	public function tear_down(): void {
+		$_POST = array();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * A user without the task view capability is refused the task list view.
+	 *
+	 * This is the Quote Manager case: they hold contact and quote capabilities,
+	 * which is enough to load a CRM list view and obtain a valid nonce, but they
+	 * must not be able to swap the requested list type for tasks.
+	 *
+	 * @return void
+	 */
+	#[TestDox( 'A quote manager cannot retrieve task list view data.' )]
+	public function test_quote_manager_cannot_retrieve_tasks() {
+
+		$this->prepare_request(
+			array(
+				'admin_zerobs_view_customers',
+				'admin_zerobs_view_quotes',
+				'admin_zerobs_customers',
+				'admin_zerobs_quotes',
+			),
+			'event'
+		);
+
+		$response = $this->fetch_list_view();
+
+		$this->assert_refused( $response );
+	}
+
+	/**
+	 * A user without the forms capability is refused the form list view.
+	 *
+	 * @return void
+	 */
+	#[TestDox( 'A quote manager cannot retrieve form list view data.' )]
+	public function test_quote_manager_cannot_retrieve_forms() {
+
+		$this->prepare_request(
+			array(
+				'admin_zerobs_view_customers',
+				'admin_zerobs_view_quotes',
+			),
+			'form'
+		);
+
+		$response = $this->fetch_list_view();
+
+		$this->assert_refused( $response );
+	}
+
+	/**
+	 * A user holding the task view capability can retrieve the task list view.
+	 *
+	 * @return void
+	 */
+	#[TestDox( 'A user with the task view capability can retrieve task list view data.' )]
+	public function test_task_viewer_can_retrieve_tasks() {
+
+		$this->prepare_request( array( 'admin_zerobs_view_events' ), 'event' );
+
+		$response = $this->fetch_list_view();
+
+		$this->assertArrayHasKey( 'objects', $response );
+		$this->assertArrayNotHasKey( 'no-action-or-rights', $response );
+	}
+
+	/**
+	 * An unrecognised list view type is refused rather than silently returning.
+	 *
+	 * @return void
+	 */
+	#[TestDox( 'An unrecognised list view type is refused.' )]
+	public function test_unknown_list_type_is_refused() {
+
+		$this->prepare_request( array( 'admin_zerobs_view_events' ), 'not-a-list-type' );
+
+		$response = $this->fetch_list_view();
+
+		$this->assert_refused( $response );
+	}
+}

--- a/tests/php/permissions/List_View_Ajax_Permissions_Test.php
+++ b/tests/php/permissions/List_View_Ajax_Permissions_Test.php
@@ -21,6 +21,30 @@ class List_View_Ajax_Permissions_Test extends WP_Ajax_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
 	/**
+	 * The ZBS instance as it stood before the test ran.
+	 *
+	 * This class cannot extend JPCRM_Base_TestCase, which is where the rest of the
+	 * suite gets its clone and restore of $GLOBALS['zbs'], because driving the
+	 * endpoint needs WP_Ajax_UnitTestCase. It is also the one class that runs the
+	 * full CRM request path, so it does the same thing here by hand.
+	 *
+	 * @var ?\ZeroBSCRM
+	 */
+	private $original_zbs;
+
+	/**
+	 * Store the initial state of ZBS.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		global $zbs;
+		$this->original_zbs = clone $zbs;
+	}
+
+	/**
 	 * Sign in as a user holding the given capabilities and prime the AJAX request.
 	 *
 	 * @param array $caps      Capabilities to grant.
@@ -65,11 +89,26 @@ class List_View_Ajax_Permissions_Test extends WP_Ajax_UnitTestCase {
 		// by the time the test runs, so PHP warns that headers were already sent.
 		// That is an artefact of running admin AJAX under the CLI test harness, so
 		// swallow just that warning and leave every other error to PHPUnit.
-		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
-			static function ( $errno, $errstr ) {
-				return str_contains( $errstr, 'Cannot modify header information' );
-			},
-			E_WARNING
+		//
+		// Everything else has to be handed back to PHPUnit's handler by hand. PHP
+		// does not walk the handler stack: an error this handler declines, or one
+		// outside a level mask, goes to PHP's own handler rather than to the handler
+		// that was in place before. Either would leave failOnWarning, failOnNotice
+		// and failOnDeprecation inert for the whole of the endpoint call, and this
+		// is the only suite that drives the list view handler.
+		$previous = set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+			static function ( $errno, $errstr, $errfile = '', $errline = 0 ) use ( &$previous ) {
+
+				if ( str_contains( $errstr, 'Cannot modify header information' ) ) {
+					return true;
+				}
+
+				if ( null === $previous ) {
+					return false;
+				}
+
+				return ( $previous )( $errno, $errstr, $errfile, $errline );
+			}
 		);
 
 		try {
@@ -105,7 +144,15 @@ class List_View_Ajax_Permissions_Test extends WP_Ajax_UnitTestCase {
 	public function tear_down(): void {
 		$_POST = array();
 
+		// Signing a user in memoises these for the rest of the request. Clear them
+		// on the way out as well as on the way in, so nothing is left behind for
+		// whatever suite runs next.
+		unset( $GLOBALS['zeroBSCRM_isZBSUser'], $GLOBALS['zeroBSCRM_isZBSBackendUser'] );
+
 		parent::tear_down();
+
+		global $zbs;
+		$zbs = $this->original_zbs;
 	}
 
 	/**

--- a/tests/php/permissions/List_View_Ajax_Permissions_Test.php
+++ b/tests/php/permissions/List_View_Ajax_Permissions_Test.php
@@ -23,8 +23,8 @@ class List_View_Ajax_Permissions_Test extends WP_Ajax_UnitTestCase {
 	/**
 	 * Sign in as a user holding the given capabilities and prime the AJAX request.
 	 *
-	 * @param array  $caps      Capabilities to grant.
-	 * @param string $list_type List view type to request.
+	 * @param array $caps      Capabilities to grant.
+	 * @param mixed $list_type List view type to request, as it arrives on the request.
 	 *
 	 * @return void
 	 */
@@ -38,6 +38,10 @@ class List_View_Ajax_Permissions_Test extends WP_Ajax_UnitTestCase {
 		}
 
 		wp_set_current_user( $user_id );
+
+		// These helpers memoise their answer in a global for the rest of the request,
+		// which outlives a single test. Clear them so each test sees its own user.
+		unset( $GLOBALS['zeroBSCRM_isZBSUser'], $GLOBALS['zeroBSCRM_isZBSBackendUser'] );
 
 		$_POST = array(
 			'action' => 'retrieveListViewData',
@@ -177,6 +181,99 @@ class List_View_Ajax_Permissions_Test extends WP_Ajax_UnitTestCase {
 	public function test_unknown_list_type_is_refused() {
 
 		$this->prepare_request( array( 'admin_zerobs_view_events' ), 'not-a-list-type' );
+
+		$response = $this->fetch_list_view();
+
+		$this->assert_refused( $response );
+	}
+
+	/**
+	 * An arrayed list view type is refused rather than tripping over itself.
+	 *
+	 * sanitize_text_field() returns an empty string for an array, so the gate sees
+	 * a type it does not recognise. Pinning that, because it rests on a detail of
+	 * how WordPress sanitises and the alternative is a PHP error in the switch.
+	 *
+	 * @return void
+	 */
+	#[TestDox( 'An arrayed list view type is refused.' )]
+	public function test_arrayed_list_type_is_refused() {
+
+		$this->prepare_request( array( 'admin_zerobs_view_customers' ), array( 'customer' ) );
+
+		$response = $this->fetch_list_view();
+
+		$this->assert_refused( $response );
+	}
+
+	/**
+	 * A list type an extension is listening for reaches the extension.
+	 *
+	 * This is the case the permission gate nearly broke. The gate has to allow the
+	 * type through *and* the handler's default arm has to fire the action, so the
+	 * assertion is that the listener ran, not that the gate said yes.
+	 *
+	 * @return void
+	 */
+	#[TestDox( 'A list type an extension is listening for reaches the extension.' )]
+	public function test_extension_list_type_reaches_the_extension() {
+
+		$fired    = false;
+		$callback = static function () use ( &$fired ) {
+			$fired = true;
+		};
+
+		add_action( 'zerobs_ajax_list_view_mailcampaign', $callback );
+
+		try {
+			// admin_zerobs_usr is granted to every CRM back end role.
+			$this->prepare_request( array( 'admin_zerobs_usr', 'admin_zerobs_view_customers' ), 'mailcampaign' );
+
+			$response = $this->fetch_list_view();
+
+			$this->assertTrue( $fired, 'The extension list view action did not fire.' );
+			$this->assertArrayNotHasKey( 'no-action-or-rights', (array) $response );
+		} finally {
+			remove_action( 'zerobs_ajax_list_view_mailcampaign', $callback );
+		}
+	}
+
+	/**
+	 * An extension list type is refused to a user with no CRM access.
+	 *
+	 * @return void
+	 */
+	#[TestDox( 'An extension list type is refused to a user with no CRM access.' )]
+	public function test_extension_list_type_is_refused_to_non_crm_users() {
+
+		$fired    = false;
+		$callback = static function () use ( &$fired ) {
+			$fired = true;
+		};
+
+		add_action( 'zerobs_ajax_list_view_mailcampaign', $callback );
+
+		try {
+			$this->prepare_request( array(), 'mailcampaign' );
+
+			$response = $this->fetch_list_view();
+
+			$this->assert_refused( $response );
+			$this->assertFalse( $fired, 'The extension list view action fired for a user with no CRM access.' );
+		} finally {
+			remove_action( 'zerobs_ajax_list_view_mailcampaign', $callback );
+		}
+	}
+
+	/**
+	 * A list type nobody is listening for is refused, whoever asks.
+	 *
+	 * @return void
+	 */
+	#[TestDox( 'A list type nobody is listening for is refused.' )]
+	public function test_extension_list_type_with_no_listener_is_refused() {
+
+		$this->prepare_request( array( 'admin_zerobs_usr', 'admin_zerobs_view_customers' ), 'mailsequence' );
 
 		$response = $this->fetch_list_view();
 

--- a/tests/php/permissions/List_View_Ajax_Permissions_Test.php
+++ b/tests/php/permissions/List_View_Ajax_Permissions_Test.php
@@ -237,9 +237,9 @@ class List_View_Ajax_Permissions_Test extends WP_Ajax_UnitTestCase {
 	/**
 	 * An arrayed list view type is refused rather than tripping over itself.
 	 *
-	 * sanitize_text_field() returns an empty string for an array, so the gate sees
-	 * a type it does not recognise. Pinning that, because it rests on a detail of
-	 * how WordPress sanitises and the alternative is a PHP error in the switch.
+	 * Because sanitize_text_field() returns an empty string for an array, the gate
+	 * sees a type it does not recognise. Pinning that, because it rests on a detail
+	 * of how WordPress sanitises and the alternative is a PHP error in the switch.
 	 *
 	 * @return void
 	 */

--- a/tests/php/permissions/List_View_Permissions_Test.php
+++ b/tests/php/permissions/List_View_Permissions_Test.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Tests for the list view type permission gate.
+ *
+ * @package Automattic\Jetpack\CRM
+ */
+
+namespace Automattic\Jetpack\CRM\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Test the capability required for each list view type.
+ */
+class List_View_Permissions_Test extends JPCRM_Base_TestCase {
+
+	/**
+	 * Create a user holding the given capabilities and make them the current user.
+	 *
+	 * @param array $caps Capabilities to grant.
+	 *
+	 * @return void
+	 */
+	private function set_current_user_with_caps( array $caps ) {
+
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$user    = get_user_by( 'id', $user_id );
+
+		foreach ( $caps as $cap ) {
+			$user->add_cap( $cap );
+		}
+
+		wp_set_current_user( $user_id );
+	}
+
+	/**
+	 * Each list view type, and the capability that unlocks it.
+	 *
+	 * @return array
+	 */
+	public static function list_type_capability_provider() {
+		return array(
+			'contacts'        => array( 'customer', 'admin_zerobs_view_customers' ),
+			'companies'       => array( 'company', 'admin_zerobs_view_customers' ),
+			'segments'        => array( 'segment', 'admin_zerobs_view_customers' ),
+			'quotes'          => array( 'quote', 'admin_zerobs_view_quotes' ),
+			'quote templates' => array( 'quotetemplate', 'admin_zerobs_view_quotes' ),
+			'invoices'        => array( 'invoice', 'admin_zerobs_view_invoices' ),
+			'transactions'    => array( 'transaction', 'admin_zerobs_view_transactions' ),
+			'tasks'           => array( 'event', 'admin_zerobs_view_events' ),
+			'forms'           => array( 'form', 'admin_zerobs_forms' ),
+		);
+	}
+
+	/**
+	 * A user holding the matching capability can view the list type.
+	 *
+	 * @param string $list_type  List view type.
+	 * @param string $capability Capability that should unlock it.
+	 *
+	 * @return void
+	 */
+	#[DataProvider( 'list_type_capability_provider' )]
+	#[TestDox( 'The matching capability grants access to a list view type.' )]
+	public function test_matching_capability_grants_access( $list_type, $capability ) {
+
+		$this->set_current_user_with_caps( array( $capability ) );
+
+		$this->assertTrue( jpcrm_perms_view_list_type( $list_type ) );
+	}
+
+	/**
+	 * A user holding every CRM view capability except the matching one is denied.
+	 *
+	 * @param string $list_type  List view type.
+	 * @param string $capability Capability that should unlock it.
+	 *
+	 * @return void
+	 */
+	#[DataProvider( 'list_type_capability_provider' )]
+	#[TestDox( 'A list view type is denied without its own capability.' )]
+	public function test_other_capabilities_do_not_grant_access( $list_type, $capability ) {
+
+		$all_caps = array(
+			'admin_zerobs_view_customers',
+			'admin_zerobs_view_quotes',
+			'admin_zerobs_view_invoices',
+			'admin_zerobs_view_transactions',
+			'admin_zerobs_view_events',
+			'admin_zerobs_forms',
+		);
+
+		$this->set_current_user_with_caps( array_diff( $all_caps, array( $capability ) ) );
+
+		$this->assertFalse( jpcrm_perms_view_list_type( $list_type ) );
+	}
+
+	/**
+	 * A Quote Manager cannot reach the task list view.
+	 *
+	 * Quote Managers hold the contact and quote view capabilities but not the
+	 * task one, so they must not be able to request the task list view.
+	 *
+	 * @return void
+	 */
+	#[TestDox( 'A quote manager cannot view the task list view.' )]
+	public function test_quote_manager_cannot_view_tasks() {
+
+		$this->set_current_user_with_caps(
+			array(
+				'admin_zerobs_view_customers',
+				'admin_zerobs_view_quotes',
+				'admin_zerobs_customers',
+				'admin_zerobs_quotes',
+			)
+		);
+
+		$this->assertTrue( jpcrm_perms_view_list_type( 'quote' ) );
+		$this->assertFalse( jpcrm_perms_view_list_type( 'event' ) );
+		$this->assertFalse( jpcrm_perms_view_list_type( 'form' ) );
+	}
+
+	/**
+	 * The task edit capability alone does not grant task list view access.
+	 *
+	 * @return void
+	 */
+	#[TestDox( 'The task edit capability alone does not grant list view access.' )]
+	public function test_task_edit_capability_does_not_grant_view() {
+
+		$this->set_current_user_with_caps( array( 'admin_zerobs_events' ) );
+
+		$this->assertFalse( jpcrm_perms_view_list_type( 'event' ) );
+	}
+
+	/**
+	 * Unrecognised list view types are denied, even for a fully capable user.
+	 *
+	 * @return void
+	 */
+	#[TestDox( 'Unrecognised list view types are denied.' )]
+	public function test_unknown_list_types_are_denied() {
+
+		$this->set_current_user_with_caps(
+			array(
+				'admin_zerobs_view_customers',
+				'admin_zerobs_view_quotes',
+				'admin_zerobs_view_invoices',
+				'admin_zerobs_view_transactions',
+				'admin_zerobs_view_events',
+				'admin_zerobs_forms',
+			)
+		);
+
+		$this->assertFalse( jpcrm_perms_view_list_type( '' ) );
+		$this->assertFalse( jpcrm_perms_view_list_type( 'not-a-list-type' ) );
+	}
+}

--- a/tests/php/permissions/List_View_Permissions_Test.php
+++ b/tests/php/permissions/List_View_Permissions_Test.php
@@ -32,6 +32,10 @@ class List_View_Permissions_Test extends JPCRM_Base_TestCase {
 		}
 
 		wp_set_current_user( $user_id );
+
+		// These helpers memoise their answer in a global for the rest of the request,
+		// which outlives a single test. Clear them so each test sees its own user.
+		unset( $GLOBALS['zeroBSCRM_isZBSUser'], $GLOBALS['zeroBSCRM_isZBSBackendUser'] );
 	}
 
 	/**
@@ -155,5 +159,71 @@ class List_View_Permissions_Test extends JPCRM_Base_TestCase {
 
 		$this->assertFalse( jpcrm_perms_view_list_type( '' ) );
 		$this->assertFalse( jpcrm_perms_view_list_type( 'not-a-list-type' ) );
+	}
+
+	/**
+	 * A list type an extension is listening for is allowed through for CRM users.
+	 *
+	 * Extensions serve their own list views by hooking
+	 * `zerobs_ajax_list_view_{$list_type}`, and apply their own check when they do.
+	 * Denying every unrecognised type would take those list views offline.
+	 */
+	#[TestDox( 'A list type an extension is listening for is allowed through for CRM users.' )]
+	public function test_extension_list_types_are_allowed_for_crm_users() {
+
+		$callback = '__return_true';
+		add_action( 'zerobs_ajax_list_view_mailcampaign', $callback );
+
+		try {
+			// admin_zerobs_usr is granted to every CRM back end role.
+			$this->set_current_user_with_caps( array( 'admin_zerobs_usr', 'admin_zerobs_view_customers' ) );
+			$this->assertTrue( jpcrm_perms_view_list_type( 'mailcampaign' ) );
+
+			// Still nothing for a type nobody is listening for.
+			$this->assertFalse( jpcrm_perms_view_list_type( 'mailsequence' ) );
+		} finally {
+			remove_action( 'zerobs_ajax_list_view_mailcampaign', $callback );
+		}
+	}
+
+	/**
+	 * An extension list type is denied to users with no CRM access at all.
+	 */
+	#[TestDox( 'An extension list type is denied to users with no CRM access at all.' )]
+	public function test_extension_list_types_are_denied_to_non_crm_users() {
+
+		$callback = '__return_true';
+		add_action( 'zerobs_ajax_list_view_mailcampaign', $callback );
+
+		try {
+			$this->set_current_user_with_caps( array() );
+			$this->assertFalse( jpcrm_perms_view_list_type( 'mailcampaign' ) );
+		} finally {
+			remove_action( 'zerobs_ajax_list_view_mailcampaign', $callback );
+		}
+	}
+
+	/**
+	 * An extension can refuse its own list type through the filter.
+	 */
+	#[TestDox( 'An extension can refuse its own list type through the filter.' )]
+	public function test_extension_can_deny_its_own_list_type_via_filter() {
+
+		$callback = '__return_true';
+		$filter   = static function ( $allowed, $list_type ) {
+			return 'mailcampaign' === $list_type ? false : $allowed;
+		};
+
+		add_action( 'zerobs_ajax_list_view_mailcampaign', $callback );
+		add_filter( 'jpcrm_perms_view_list_type', $filter, 10, 2 );
+
+		try {
+			// admin_zerobs_usr is granted to every CRM back end role.
+			$this->set_current_user_with_caps( array( 'admin_zerobs_usr', 'admin_zerobs_view_customers' ) );
+			$this->assertFalse( jpcrm_perms_view_list_type( 'mailcampaign' ) );
+		} finally {
+			remove_filter( 'jpcrm_perms_view_list_type', $filter, 10 );
+			remove_action( 'zerobs_ajax_list_view_mailcampaign', $callback );
+		}
 	}
 }

--- a/tests/php/permissions/List_View_Permissions_Test.php
+++ b/tests/php/permissions/List_View_Permissions_Test.php
@@ -60,6 +60,8 @@ class List_View_Permissions_Test extends JPCRM_Base_TestCase {
 	/**
 	 * A user holding the matching capability can view the list type.
 	 *
+	 * @dataProvider list_type_capability_provider
+	 *
 	 * @param string $list_type  List view type.
 	 * @param string $capability Capability that should unlock it.
 	 *
@@ -76,6 +78,8 @@ class List_View_Permissions_Test extends JPCRM_Base_TestCase {
 
 	/**
 	 * A user holding every CRM view capability except the matching one is denied.
+	 *
+	 * @dataProvider list_type_capability_provider
 	 *
 	 * @param string $list_type  List view type.
 	 * @param string $capability Capability that should unlock it.
@@ -276,5 +280,17 @@ class List_View_Permissions_Test extends JPCRM_Base_TestCase {
 		} finally {
 			remove_filter( 'jpcrm_perms_view_list_type', $filter, 10 );
 		}
+	}
+
+	/**
+	 * Clear the memoised permission globals so they do not leak into the next test.
+	 *
+	 * @return void
+	 */
+	public function tear_down(): void {
+
+		unset( $GLOBALS['zeroBSCRM_isZBSUser'], $GLOBALS['zeroBSCRM_isZBSBackendUser'] );
+
+		parent::tear_down();
 	}
 }

--- a/tests/php/permissions/List_View_Permissions_Test.php
+++ b/tests/php/permissions/List_View_Permissions_Test.php
@@ -226,4 +226,55 @@ class List_View_Permissions_Test extends JPCRM_Base_TestCase {
 			remove_action( 'zerobs_ajax_list_view_mailcampaign', $callback );
 		}
 	}
+
+	/**
+	 * The filter can refuse one of our own list types.
+	 */
+	#[TestDox( 'The filter can refuse one of our own list types.' )]
+	public function test_filter_can_deny_a_core_list_type() {
+
+		$filter = static function ( $allowed, $list_type ) {
+			return 'invoice' === $list_type ? false : $allowed;
+		};
+
+		add_filter( 'jpcrm_perms_view_list_type', $filter, 10, 2 );
+
+		try {
+			$this->set_current_user_with_caps( array( 'admin_zerobs_view_invoices', 'admin_zerobs_view_quotes' ) );
+
+			$this->assertFalse( jpcrm_perms_view_list_type( 'invoice' ) );
+
+			// Other list types are untouched.
+			$this->assertTrue( jpcrm_perms_view_list_type( 'quote' ) );
+		} finally {
+			remove_filter( 'jpcrm_perms_view_list_type', $filter, 10 );
+		}
+	}
+
+	/**
+	 * The filter can allow one of our own list types to a user without the capability.
+	 *
+	 * This is the case the filter exists for on our own types: granting a custom
+	 * role access to a list view without granting it the capability outright.
+	 */
+	#[TestDox( 'The filter can allow one of our own list types to a user without the capability.' )]
+	public function test_filter_can_allow_a_core_list_type() {
+
+		$filter = static function ( $allowed, $list_type ) {
+			return 'event' === $list_type ? true : $allowed;
+		};
+
+		add_filter( 'jpcrm_perms_view_list_type', $filter, 10, 2 );
+
+		try {
+			$this->set_current_user_with_caps( array( 'admin_zerobs_view_quotes' ) );
+
+			$this->assertTrue( jpcrm_perms_view_list_type( 'event' ) );
+
+			// Still nothing for the list types the filter does not touch.
+			$this->assertFalse( jpcrm_perms_view_list_type( 'form' ) );
+		} finally {
+			remove_filter( 'jpcrm_perms_view_list_type', $filter, 10 );
+		}
+	}
 }


### PR DESCRIPTION
## What

`retrieveListViewData` serves every CRM list view. The list type comes in on the request, and the handler checked the current user's view permission for most of the types it accepts, but not all of them — tasks and forms had no check, so they were served to any user who could reach the endpoint.

This replaces the chain of per-type checks with a single lookup, `jpcrm_perms_view_list_type()`, covering all nine list types and denying anything it does not recognise. Previously an unrecognised type fell through to a `200` with an empty body.

Task and form capabilities follow what their admin pages already require:

| List type | Capability |
| --- | --- |
| `customer`, `company`, `segment` | `admin_zerobs_view_customers` |
| `quote`, `quotetemplate` | `admin_zerobs_view_quotes` |
| `invoice` | `admin_zerobs_view_invoices` |
| `transaction` | `admin_zerobs_view_transactions` |
| `event` | `admin_zerobs_view_events` |
| `form` | `admin_zerobs_forms` |

Tasks needed a new `jpcrm_perms_view_tasks()` helper. The existing `zeroBSCRM_perms_tasks()` checks `admin_zerobs_events`, which is the edit capability, and the task *list* pages register with the view capability: Task Scheduler, Task List and Task Tags all use `'perms' => 'admin_zerobs_view_events'` in `ZeroBSCRM.Core.Menus.WP.php`, and only Add New Task uses `admin_zerobs_events`. The endpoint behind a list view should ask for the same capability as the page.

To be clear about what this does not do: no shipped role would have been locked out by using the edit capability instead, because every role that grants `admin_zerobs_view_events` also grants `admin_zerobs_events` a few lines later in `ZeroBSCRM.Permissions.php`. The reason for the new helper is matching the page, not preventing a lockout. Noting it because it is the sort of thing someone later folds back into `zeroBSCRM_perms_tasks()` on the grounds that it looks redundant.

`segment` and `quotetemplate` are gated on the view capabilities above, while their admin pages register with the edit capabilities (`admin_zerobs_customers` and `admin_zerobs_quotes`). That mismatch is pre-existing and carried over unchanged. It makes no difference for `segment`, where every role granting the view capability grants the edit one too, but it does for `quotetemplate`: Mail Manager holds `admin_zerobs_view_quotes` and not `admin_zerobs_quotes`, so it cannot open the Quote Templates page but can fetch that list over AJAX. Same before this change as after. #35 covers settling which of the two capabilities is the right one, rather than tightening it as a drive-by here.

The response for a refused request is unchanged (`no-action-or-rights`), so the JS caller behaves exactly as it does today.

## Extension list views

The handler's `default:` arm is not dead code. It fires `zerobs_ajax_list_view_{$list_type}` so extensions can serve their own list views, and Mail Campaigns registers two of them, `mailcampaign` and `mailsequence`. Denying every unrecognised type would have taken those offline for everyone, because the gate returns before the switch is reached.

So unrecognised types now go one of two ways:

- Something is listening for the type, and the request came from a user with CRM backend access: it reaches the extension as it did before, and the extension is responsible for the capability check for the list views it serves. That is how the hook already works — the comment on it reads "funcs which fire here have to return internally, they can't rely on `$res` return".
- Nothing is listening: denied, as with any other unknown type. A made up list type still fails closed. Someone with no CRM access at all is denied either way, which is tighter than before.

An extension can apply that check in its hook callback, or through the new `jpcrm_perms_view_list_type` filter.

That filter wraps the answer for every list type, ours included, so a site can widen or narrow access to any list view — granting a custom role the task list without granting it `admin_zerobs_view_events`, say.

## Testing

New `permissions` test suite, added to `phpunit.9.xml.dist` and `phpunit.11.xml.dist` (`.12` is a symlink to `.11`):

- `List_View_Permissions_Test` — every list type against its capability, and every list type denied when the user holds all the *other* CRM capabilities. Also covers unrecognised types, extension supplied types with and without a listener, the filter refusing and allowing both an extension type and one of ours, and the task edit-vs-view capability distinction.
- `List_View_Ajax_Permissions_Test` — drives the endpoint itself through `WP_Ajax_UnitTestCase` with a valid nonce. Tasks and forms refused to a Quote Manager, tasks served to someone holding the view capability, and the three carve-out states: an extension type reaches the extension, is refused to a user with no CRM access, and is refused when nobody is listening. Plus an unrecognised type and an arrayed one.

I confirmed the endpoint tests, the extension list view test and the two filter tests fail without the change they cover, and pass with it. Full suite is green: 76 tests, 251 assertions.

Four notes on the tests:

- They are deliberately **not** in the `ajax` group. Neither phpunit config excludes any group, so this changes nothing here, but the group is skipped by convention in other WordPress setups and these should always run.
- The carve-out test asserts that the listener ran, not that the gate said yes. Fires the real endpoint, so it covers the gate and the `default:` arm together, which is the pair that has to agree for an extension list view to keep working. Back the carve-out out and it fails.
- Both test classes clear the `$zeroBSCRM_isZBSUser` and `$zeroBSCRM_isZBSBackendUser` globals when they sign a user in. Those helpers memoise for the rest of the request, which outlives a single test, and the carve-out is the one path that reads them — without clearing, the test for a user with no CRM access reads the answer memoised by the test before it.
- `fetch_list_view()` swallows one PHP warning. `admin_init` sends admin headers, and PHPUnit has already written to stdout by then, so PHP warns that headers were already sent — with `failOnWarning="true"` that is a hard failure. It is an artefact of running admin AJAX under the CLI harness, so the suppression is scoped to that one message and restored in a `finally`.

## To verify manually

As a user with a CRM role that does not include `admin_zerobs_view_events` (Quote Manager, Invoice Manager or Transaction Manager), open a list view they can see, then POST to `admin-ajax.php` with the same nonce and `v[listtype]=event`. Before: task records. After: `no-action-or-rights`. The same holds for `v[listtype]=form`.

Users who should reach those list views are unaffected — worth a click through Task Scheduler, Task List and Forms as an admin, and as a Contact Manager for the task views.

With Mail Campaigns active, the campaign and sequence list views should load exactly as before. The carve-out rests on the extension's hooks being registered by the time `wp_ajax_retrieveListViewData` fires, so I traced that rather than assuming it: `add_action( 'zerobs_ajax_list_view_mailcampaign', ... )` and its `mailsequence` sibling sit at file scope in `ZeroBSCRM_MailCampaigns.List.Campaigns.php`, which `zeroBSCRM_MailCampaignsinit()` requires unconditionally on `after_zerobscrm_settings_init`. Core fires that inside `ZeroBSCRM::init()` on `init` priority 10, which is well before `admin-ajax.php` gets to `admin_init` and the `wp_ajax_` hook. Mail Campaigns is also the only extension registering the hook — nothing else in jetpack-crm-extensions does.

### Release Notes

* Check that the current user may view a list view type before returning its data. Task and form list views were not checked before.
* Add a `jpcrm_perms_view_list_type` filter, so a site can grant or deny access to any list view. Use it if custom code shows a task or form list view behind a different capability.
