### PR TITLE
Don't let self-reported details replace contact fields already filled in

### DIFF
--- a/includes/ZeroBSCRM.AJAX.php
+++ b/includes/ZeroBSCRM.AJAX.php
@@ -1420,7 +1420,12 @@ function zbs_lead_form_capture() {
 						$fallBackLog,
 						false, // } Extra meta
 						// } Internal automator overrides - here we pass a "customer.create" note override (so we can pass it a custom str, else we let it fall back to "created by form")
-						$internalAutomatorOverride
+						$internalAutomatorOverride,
+						'update',
+						'zbsc_',
+						// } This endpoint takes submissions from anyone, against any email address,
+						// } so a submission must not reset the status of an existing contact.
+						array( 'status' )
 					);
 
 					// 2.97.7 - added this:
@@ -1478,7 +1483,12 @@ function zbs_lead_form_capture() {
 						$fallBackLog,
 						false, // } Extra meta
 						// } Internal automator overrides - here we pass a "customer.create" note override (so we can pass it a custom str, else we let it fall back to "created by form")
-						$internalAutomatorOverride
+						$internalAutomatorOverride,
+						'update',
+						'zbsc_',
+						// } This endpoint takes submissions from anyone, against any email address,
+						// } so a submission may fill these in on an existing contact but not replace them.
+						array( 'fname', 'status' )
 					);
 
 					break;
@@ -1521,7 +1531,12 @@ function zbs_lead_form_capture() {
 						$fallBackLog,
 						false, // } Extra meta
 						// } Internal automator overrides - here we pass a "customer.create" note override (so we can pass it a custom str, else we let it fall back to "created by form")
-						$internalAutomatorOverride
+						$internalAutomatorOverride,
+						'update',
+						'zbsc_',
+						// } This endpoint takes submissions from anyone, against any email address,
+						// } so a submission may fill these in on an existing contact but not replace them.
+						array( 'fname', 'lname', 'status' )
 					);
 
 					// 2.97.7 - added this:

--- a/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -1781,7 +1781,8 @@ function zeroBS_addUpdateCustomer(
 	$extraMeta = false,
 	$automatorPassthrough = false,
 	$owner = -1,
-	$metaBuilderPrefix = 'zbsc_'
+	$metaBuilderPrefix = 'zbsc_',
+	$do_not_overwrite_populated = array()
 ) {
 
 	#} return
@@ -1955,11 +1956,12 @@ function zeroBS_addUpdateCustomer(
 		// DB2 update_post_meta($postID, 'zbs_customer_meta', $zbsCustomerMeta);
 		return $zbs->DAL->contacts->addUpdateContact(
 			array(
-				'id'                   => $cID,
-				'data'                 => $zbsCustomerMeta,
-				'extraMeta'            => $extraMeta,
-				'automatorPassthrough' => $automatorPassthrough,
-				'fallBackLog'          => $fallBackLog,
+				'id'                         => $cID,
+				'data'                       => $zbsCustomerMeta,
+				'extraMeta'                  => $extraMeta,
+				'automatorPassthrough'       => $automatorPassthrough,
+				'fallBackLog'                => $fallBackLog,
+				'do_not_overwrite_populated' => $do_not_overwrite_populated,
 			)
 		);
 

--- a/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
+++ b/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
@@ -2757,6 +2757,22 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 
 			if ( is_array( $existing_contact ) ) {
 
+				/*
+				 * Until we add multi-address support, `getContact()` hands the second
+				 * address back under its old field names, so a field written as
+				 * `secaddr1` reads back as `secaddr_addr1`. Translate before looking a
+				 * protected field up on the record, or it never matches and the field is
+				 * replaced as though it had been left out of the list.
+				 */
+				$stored_field_names = array(
+					'secaddr1'    => 'secaddr_addr1',
+					'secaddr2'    => 'secaddr_addr2',
+					'seccity'     => 'secaddr_city',
+					'seccounty'   => 'secaddr_county',
+					'seccountry'  => 'secaddr_country',
+					'secpostcode' => 'secaddr_postcode',
+				);
+
 				foreach ( $do_not_overwrite_populated as $protected_field ) {
 
 					// Nothing to overwrite with.
@@ -2764,14 +2780,16 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 						continue;
 					}
 
+					$stored_field = isset( $stored_field_names[ $protected_field ] ) ? $stored_field_names[ $protected_field ] : $protected_field;
+
 					// Nothing on record yet, so let it be filled in.
-					if ( ! isset( $existing_contact[ $protected_field ] ) || '' === $existing_contact[ $protected_field ] ) {
+					if ( ! isset( $existing_contact[ $stored_field ] ) || '' === $existing_contact[ $stored_field ] ) {
 						continue;
 					}
 
 					// Hold the stored value rather than unsetting the key, so this behaves the
 					// same way whether or not the caller also passed `do_not_update_blanks`.
-					$data[ $protected_field ] = $existing_contact[ $protected_field ];
+					$data[ $protected_field ] = $existing_contact[ $stored_field ];
 				}
 			}
 		}

--- a/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
+++ b/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
@@ -2522,6 +2522,10 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 
 			'do_not_update_blanks' => false, // this allows you to not update fields if blank (same as fieldoverride for extsource -> in)
 
+			// Field keys (unprefixed) which may be filled in on an existing contact, but not replaced.
+			// For callers passing details self-reported through a checkout or form. See below.
+			'do_not_overwrite_populated' => array(),
+
 		);
 		foreach ( $defaultArgs as $argK => $argV ) {
 			$$argK = $argV;
@@ -2733,6 +2737,46 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 		}
 
 		#} ========= / CHECK FIELDS ===========
+
+		// ========= SELF-REPORTED SOURCE (Deny overwrites of populated fields) ===========
+
+		/*
+		 * Contacts are matched by email address, so a caller which passes contact data
+		 * without an ID updates whichever contact already holds that email (see the email
+		 * lookup above). Where the details came from a CRM user, or from someone signed in
+		 * to an account, replacing what is on record is the right outcome.
+		 *
+		 * Details typed into a checkout or a form that anyone can fill in are weaker than
+		 * that: the email address was entered alongside everything else, and the contact it
+		 * matches may hold details a CRM user has since corrected. Callers handling those
+		 * name the fields here, and we fill them in when blank rather than replace them.
+		 */
+		if ( is_array( $do_not_overwrite_populated ) && count( $do_not_overwrite_populated ) > 0 && ! empty( $id ) && $id > 0 ) {
+
+			$existing_contact = $this->getContact( $id, array( 'withCustomFields' => false ) );
+
+			if ( is_array( $existing_contact ) ) {
+
+				foreach ( $do_not_overwrite_populated as $protected_field ) {
+
+					// Nothing to overwrite with.
+					if ( ! isset( $data[ $protected_field ] ) ) {
+						continue;
+					}
+
+					// Nothing on record yet, so let it be filled in.
+					if ( ! isset( $existing_contact[ $protected_field ] ) || '' === $existing_contact[ $protected_field ] ) {
+						continue;
+					}
+
+					// Hold the stored value rather than unsetting the key, so this behaves the
+					// same way whether or not the caller also passed `do_not_update_blanks`.
+					$data[ $protected_field ] = $existing_contact[ $protected_field ];
+				}
+			}
+		}
+
+		// ========= / SELF-REPORTED SOURCE ===========
 
 		#} ========= OVERRIDE SETTING (Deny blank overrides) ===========
 

--- a/includes/ZeroBSCRM.IntegrationFuncs.php
+++ b/includes/ZeroBSCRM.IntegrationFuncs.php
@@ -214,7 +214,7 @@ function zeroBS_integrations_getCustomer( $externalSource = '', $externalID = ''
 	|   False (boolean) (customer create/update failed)
 	|=======================================
 */
-function zeroBS_integrations_addOrUpdateCustomer( $externalSource = '', $externalID = '', $customerFields = array(), $customerDate = '', $fallbackLog = 'auto', $extraMeta = false, $automatorPassthroughArray = false, $emailAlreadyExistsAction = 'update', $fieldPrefix = 'zbsc_' ) {
+function zeroBS_integrations_addOrUpdateCustomer( $externalSource = '', $externalID = '', $customerFields = array(), $customerDate = '', $fallbackLog = 'auto', $extraMeta = false, $automatorPassthroughArray = false, $emailAlreadyExistsAction = 'update', $fieldPrefix = 'zbsc_', $do_not_overwrite_populated = array() ) {
 
 	#} leave this true and it'll run as normal.
 	$usualUpdate = true;
@@ -319,7 +319,7 @@ function zeroBS_integrations_addOrUpdateCustomer( $externalSource = '', $externa
 
 			#} Brutal add/update
 			#} MS - 3rd Jan 2019 - this (eventually) just calls the usual _addUpdateCustomer function
-			$customerID = zeroBS_addUpdateCustomer( $potentialCustomerID, $customerFields, $externalSource, $externalID, $customerDate, $fallbackLogToPass, $extraMeta, $automatorPassthrough, -1, $fieldPrefix );
+			$customerID = zeroBS_addUpdateCustomer( $potentialCustomerID, $customerFields, $externalSource, $externalID, $customerDate, $fallbackLogToPass, $extraMeta, $automatorPassthrough, -1, $fieldPrefix, $do_not_overwrite_populated );
 			return $customerID;
 
 		} #} / usual update

--- a/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -757,6 +757,62 @@ class Woo_Sync_Background_Sync_Job {
 	}
 
 	/**
+	 * Returns the contact fields an order is allowed to fill in but not replace.
+	 *
+	 * Billing details on a guest order are whatever was typed at the checkout. Because
+	 * contacts are matched on the billing email, an existing contact would otherwise take
+	 * on that name, address and telephone number, replacing details a CRM user may have
+	 * corrected by hand.
+	 *
+	 * Orders belonging to a logged-in WooCommerce customer are left alone: the account
+	 * tells us whose details these are, so they should still update freely. Blank fields
+	 * on the contact are filled in either way, which is where most of the value of
+	 * syncing billing details lies.
+	 *
+	 * @param array $crm_object_data Woo order data passed through `woocommerce_order_to_crm_objects`.
+	 *
+	 * @return array Field keys to protect, empty for orders from a logged-in customer.
+	 */
+	private function contact_fields_to_protect( $crm_object_data ) {
+
+		// `wpid` is only set for orders with a WooCommerce customer account behind them.
+		$is_guest_order = empty( $crm_object_data['contact']['wpid'] );
+
+		$fields = array();
+
+		if ( $is_guest_order ) {
+			$fields = array(
+				'fname',
+				'lname',
+				'addr1',
+				'addr2',
+				'city',
+				'county',
+				'postcode',
+				'country',
+				'hometel',
+				'secaddr1',
+				'secaddr2',
+				'seccity',
+				'seccounty',
+				'secpostcode',
+				'seccountry',
+			);
+		}
+
+		/**
+		 * Filters the contact fields a Woo order may fill in but not replace.
+		 *
+		 * Returning an empty array restores the previous behaviour, where an order
+		 * overwrote these fields on whichever contact held the billing email address.
+		 *
+		 * @param array $fields          Field keys to protect.
+		 * @param array $crm_object_data The order data being imported.
+		 */
+		return apply_filters( 'jpcrm_woosync_contact_fields_to_protect', $fields, $crm_object_data );
+	}
+
+	/**
 	 * Adds or updates crm objects related to a processed woocommerce order
 	 *  (requires that the $order_data has been passed through `woocommerce_order_to_crm_objects`)
 	 *  Previously `import_woocommerce_order_from_order_data`
@@ -778,9 +834,10 @@ class Woo_Sync_Background_Sync_Job {
 			// Add the contact
 			$contact_id = $zbs->DAL->contacts->addUpdateContact(
 				array(
-					'data'                 => $crm_object_data['contact'],
-					'extraMeta'            => $crm_object_data['contact_extra_meta'],
-					'do_not_update_blanks' => true,
+					'data'                       => $crm_object_data['contact'],
+					'extraMeta'                  => $crm_object_data['contact_extra_meta'],
+					'do_not_update_blanks'       => true,
+					'do_not_overwrite_populated' => $this->contact_fields_to_protect( $crm_object_data ),
 				)
 			);
 

--- a/tests/php/entities/Contact_Field_Protection_Test.php
+++ b/tests/php/entities/Contact_Field_Protection_Test.php
@@ -43,6 +43,12 @@ class Contact_Field_Protection_Test extends JPCRM_Base_Integration_TestCase {
 		'postcode',
 		'country',
 		'hometel',
+		'secaddr1',
+		'secaddr2',
+		'seccity',
+		'seccounty',
+		'secpostcode',
+		'seccountry',
 	);
 
 	/**
@@ -64,12 +70,15 @@ class Contact_Field_Protection_Test extends JPCRM_Base_Integration_TestCase {
 		$data = $this->generate_contact_data(
 			array_merge(
 				array(
-					'email'    => self::CONTACT_EMAIL,
-					'fname'    => 'Alex',
-					'lname'    => 'Murphy',
-					'addr1'    => '19 Prospect Hill',
-					'hometel'  => '+353 21 427 0000',
-					'postcode' => 'T12 XY45',
+					'email'       => self::CONTACT_EMAIL,
+					'fname'       => 'Alex',
+					'lname'       => 'Murphy',
+					'addr1'       => '19 Prospect Hill',
+					'hometel'     => '+353 21 427 0000',
+					'postcode'    => 'T12 XY45',
+					'secaddr1'    => '4 Wellington Road',
+					'seccity'     => 'Cork',
+					'secpostcode' => 'T23 CD34',
 				),
 				$overrides
 			)
@@ -89,12 +98,15 @@ class Contact_Field_Protection_Test extends JPCRM_Base_Integration_TestCase {
 	 */
 	private function self_reported_data(): array {
 		return array(
-			'email'    => self::CONTACT_EMAIL,
-			'fname'    => 'alex',
-			'lname'    => 'murph',
-			'addr1'    => '66 Sundays Well Road',
-			'hometel'  => '+353 21 427 0001',
-			'postcode' => 'T23 AB12',
+			'email'       => self::CONTACT_EMAIL,
+			'fname'       => 'alex',
+			'lname'       => 'murph',
+			'addr1'       => '66 Sundays Well Road',
+			'hometel'     => '+353 21 427 0001',
+			'postcode'    => 'T23 AB12',
+			'secaddr1'    => '12 Blarney Street',
+			'seccity'     => 'Ballincollig',
+			'secpostcode' => 'P31 EF56',
 		);
 	}
 
@@ -125,6 +137,11 @@ class Contact_Field_Protection_Test extends JPCRM_Base_Integration_TestCase {
 		$this->assertSame( '19 Prospect Hill', $contact['addr1'], 'Address was replaced.' );
 		$this->assertSame( '+353 21 427 0000', $contact['hometel'], 'Telephone number was replaced.' );
 		$this->assertSame( 'T12 XY45', $contact['postcode'], 'Postcode was replaced.' );
+
+		// The second address is written as `secaddr1` and read back as `secaddr_addr1`.
+		$this->assertSame( '4 Wellington Road', $contact['secaddr_addr1'], 'Shipping address was replaced.' );
+		$this->assertSame( 'Cork', $contact['secaddr_city'], 'Shipping city was replaced.' );
+		$this->assertSame( 'T23 CD34', $contact['secaddr_postcode'], 'Shipping postcode was replaced.' );
 	}
 
 	/**
@@ -160,6 +177,37 @@ class Contact_Field_Protection_Test extends JPCRM_Base_Integration_TestCase {
 
 		$this->assertSame( 'Flat 4', $contact['addr2'], 'An empty field should still be filled in from an order or form.' );
 		$this->assertSame( 'Cork', $contact['city'], 'An empty field should still be filled in from an order or form.' );
+	}
+
+	/**
+	 * @testdox An empty second address is still filled in from a shipping address.
+	 */
+	#[TestDox( 'An empty second address is still filled in from a shipping address.' )]
+	public function test_empty_second_address_is_still_filled() {
+		global $zbs;
+
+		// Nothing on record for the second address.
+		$contact_id = $this->create_tidied_contact(
+			array(
+				'secaddr1'    => '',
+				'seccity'     => '',
+				'secpostcode' => '',
+			)
+		);
+
+		$zbs->DAL->contacts->addUpdateContact(
+			array(
+				'data'                       => $this->self_reported_data(),
+				'do_not_update_blanks'       => true,
+				'do_not_overwrite_populated' => self::PROTECTED_FIELDS,
+			)
+		);
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( '12 Blarney Street', $contact['secaddr_addr1'], 'An empty shipping address should still be filled in.' );
+		$this->assertSame( 'Ballincollig', $contact['secaddr_city'], 'An empty shipping city should still be filled in.' );
+		$this->assertSame( 'P31 EF56', $contact['secaddr_postcode'], 'An empty shipping postcode should still be filled in.' );
 	}
 
 	/**

--- a/tests/php/entities/Contact_Field_Protection_Test.php
+++ b/tests/php/entities/Contact_Field_Protection_Test.php
@@ -1,0 +1,332 @@
+<?php
+/**
+ * Tests for the `do_not_overwrite_populated` option on contact add/update.
+ *
+ * Contacts are identified by email address. A caller that hands
+ * `addUpdateContact()` a set of fields without a contact ID therefore updates
+ * whichever contact already holds that email.
+ *
+ * That is what we want when the details come from someone who has signed in,
+ * or from a CRM user. It is less obviously right when they come from a
+ * checkout or a form that anyone can fill in, where the email address is
+ * typed alongside everything else. `do_not_overwrite_populated` lets those
+ * callers name the fields that should be filled in when blank and otherwise
+ * left as they are.
+ *
+ * @package Automattic\Jetpack\CRM
+ */
+
+namespace Automattic\Jetpack\CRM\Entities\Tests;
+
+use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Test the populated-field protection used for self-reported contact details.
+ */
+class Contact_Field_Protection_Test extends JPCRM_Base_Integration_TestCase {
+
+	/**
+	 * Fields a self-reported source may fill in but not replace.
+	 *
+	 * Mirrors the list Woo Sync passes for guest orders.
+	 *
+	 * @var string[]
+	 */
+	private const PROTECTED_FIELDS = array(
+		'fname',
+		'lname',
+		'addr1',
+		'addr2',
+		'city',
+		'county',
+		'postcode',
+		'country',
+		'hometel',
+	);
+
+	/**
+	 * The email address both sides of each test share.
+	 *
+	 * @var string
+	 */
+	private const CONTACT_EMAIL = 'alex.murphy@example.test';
+
+	/**
+	 * Create a contact holding details a CRM user has already tidied up.
+	 *
+	 * @param array $overrides Field overrides.
+	 * @return int The new contact ID.
+	 */
+	private function create_tidied_contact( array $overrides = array() ): int {
+		global $zbs;
+
+		$data = $this->generate_contact_data(
+			array_merge(
+				array(
+					'email'    => self::CONTACT_EMAIL,
+					'fname'    => 'Alex',
+					'lname'    => 'Murphy',
+					'addr1'    => '19 Prospect Hill',
+					'hometel'  => '+353 21 427 0000',
+					'postcode' => 'T12 XY45',
+				),
+				$overrides
+			)
+		);
+
+		$id = $zbs->DAL->contacts->addUpdateContact( array( 'data' => $data ) );
+
+		$this->assertGreaterThan( 0, $id, 'Failed to create the contact under test.' );
+
+		return $id;
+	}
+
+	/**
+	 * Details typed into a checkout or form against the same email address.
+	 *
+	 * @return array
+	 */
+	private function self_reported_data(): array {
+		return array(
+			'email'    => self::CONTACT_EMAIL,
+			'fname'    => 'alex',
+			'lname'    => 'murph',
+			'addr1'    => '66 Sundays Well Road',
+			'hometel'  => '+353 21 427 0001',
+			'postcode' => 'T23 AB12',
+		);
+	}
+
+	/**
+	 * @testdox Self-reported details do not replace fields that are already filled in.
+	 */
+	#[TestDox( 'Self-reported details do not replace fields that are already filled in.' )]
+	public function test_populated_fields_are_not_overwritten() {
+		global $zbs;
+
+		$contact_id = $this->create_tidied_contact();
+
+		$returned_id = $zbs->DAL->contacts->addUpdateContact(
+			array(
+				'data'                       => $this->self_reported_data(),
+				'do_not_update_blanks'       => true,
+				'do_not_overwrite_populated' => self::PROTECTED_FIELDS,
+			)
+		);
+
+		// Matching on email still resolves to the same record. That part is intentional.
+		$this->assertSame( $contact_id, (int) $returned_id, 'Expected the email match to resolve to the existing contact.' );
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( 'Alex', $contact['fname'], 'First name was replaced.' );
+		$this->assertSame( 'Murphy', $contact['lname'], 'Last name was replaced.' );
+		$this->assertSame( '19 Prospect Hill', $contact['addr1'], 'Address was replaced.' );
+		$this->assertSame( '+353 21 427 0000', $contact['hometel'], 'Telephone number was replaced.' );
+		$this->assertSame( 'T12 XY45', $contact['postcode'], 'Postcode was replaced.' );
+	}
+
+	/**
+	 * @testdox Self-reported details still fill in fields that are empty.
+	 */
+	#[TestDox( 'Self-reported details still fill in fields that are empty.' )]
+	public function test_empty_fields_are_still_filled() {
+		global $zbs;
+
+		// Nothing on record for the second address line or the city.
+		$contact_id = $this->create_tidied_contact(
+			array(
+				'addr2' => '',
+				'city'  => '',
+			)
+		);
+
+		$zbs->DAL->contacts->addUpdateContact(
+			array(
+				'data'                       => array_merge(
+					$this->self_reported_data(),
+					array(
+						'addr2' => 'Flat 4',
+						'city'  => 'Cork',
+					)
+				),
+				'do_not_update_blanks'       => true,
+				'do_not_overwrite_populated' => self::PROTECTED_FIELDS,
+			)
+		);
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( 'Flat 4', $contact['addr2'], 'An empty field should still be filled in from an order or form.' );
+		$this->assertSame( 'Cork', $contact['city'], 'An empty field should still be filled in from an order or form.' );
+	}
+
+	/**
+	 * @testdox Fields outside the protected list are still updated.
+	 */
+	#[TestDox( 'Fields outside the protected list are still updated.' )]
+	public function test_unprotected_fields_are_still_updated() {
+		global $zbs;
+
+		$contact_id = $this->create_tidied_contact( array( 'mobtel' => '33333333' ) );
+
+		$zbs->DAL->contacts->addUpdateContact(
+			array(
+				'data'                       => array_merge(
+					$this->self_reported_data(),
+					array( 'mobtel' => '44444444' )
+				),
+				'do_not_update_blanks'       => true,
+				// Note: `mobtel` is deliberately absent from this list.
+				'do_not_overwrite_populated' => self::PROTECTED_FIELDS,
+			)
+		);
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( '44444444', $contact['mobtel'], 'Only the named fields should be protected.' );
+	}
+
+	/**
+	 * @testdox A brand new contact is created with all the details supplied.
+	 */
+	#[TestDox( 'A brand new contact is created with all the details supplied.' )]
+	public function test_new_contact_is_unaffected() {
+		global $zbs;
+
+		$contact_id = $zbs->DAL->contacts->addUpdateContact(
+			array(
+				'data'                       => array(
+					'email' => 'first.time.buyer@example.test',
+					'fname' => 'Robin',
+					'lname' => 'Kelly',
+					'addr1' => '1 Barrack Street',
+				),
+				'do_not_update_blanks'       => true,
+				'do_not_overwrite_populated' => self::PROTECTED_FIELDS,
+			)
+		);
+
+		$this->assertGreaterThan( 0, $contact_id, 'A new contact should still be created.' );
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( 'Robin', $contact['fname'], 'A new contact should keep the details it was created with.' );
+		$this->assertSame( '1 Barrack Street', $contact['addr1'], 'A new contact should keep the details it was created with.' );
+	}
+
+	/**
+	 * Submit through the same helper, with the same arguments, the lead capture
+	 * endpoint uses for a 'zbs_cgrab' form.
+	 *
+	 * @param array $fields Contact fields, `zbsc_` prefixed as the endpoint passes them.
+	 * @return int|false The contact ID.
+	 */
+	private function submit_lead_form( array $fields ) {
+		return zeroBS_integrations_addOrUpdateCustomer(
+			'form',
+			$fields['zbsc_email'],
+			$fields,
+			'',
+			'none',
+			false,
+			false,
+			'update',
+			'zbsc_',
+			array( 'fname', 'lname', 'status' )
+		);
+	}
+
+	/**
+	 * @testdox A form submission does not replace a name that is already filled in.
+	 */
+	#[TestDox( 'A form submission does not replace a name that is already filled in.' )]
+	public function test_form_submission_does_not_replace_populated_name() {
+		global $zbs;
+
+		$contact_id = $this->create_tidied_contact();
+
+		$this->submit_lead_form(
+			array(
+				'zbsc_status' => 'Lead',
+				'zbsc_email'  => self::CONTACT_EMAIL,
+				'zbsc_fname'  => 'alex',
+				'zbsc_lname'  => 'murph',
+			)
+		);
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( 'Alex', $contact['fname'], 'A form submission replaced a first name already on record.' );
+		$this->assertSame( 'Murphy', $contact['lname'], 'A form submission replaced a last name already on record.' );
+	}
+
+	/**
+	 * @testdox A form submission does not reset the status of an existing contact.
+	 */
+	#[TestDox( 'A form submission does not reset the status of an existing contact.' )]
+	public function test_form_submission_does_not_reset_status() {
+		global $zbs;
+
+		$contact_id = $this->create_tidied_contact( array( 'status' => 'Customer' ) );
+
+		$this->submit_lead_form(
+			array(
+				'zbsc_status' => 'Lead',
+				'zbsc_email'  => self::CONTACT_EMAIL,
+				'zbsc_fname'  => 'Alex',
+				'zbsc_lname'  => 'Murphy',
+			)
+		);
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( 'Customer', $contact['status'], 'A form submission moved an existing customer back to a lead.' );
+	}
+
+	/**
+	 * @testdox A form submission still captures a contact that does not exist yet.
+	 */
+	#[TestDox( 'A form submission still captures a contact that does not exist yet.' )]
+	public function test_form_submission_still_creates_new_contacts() {
+		global $zbs;
+
+		$contact_id = $this->submit_lead_form(
+			array(
+				'zbsc_status' => 'Lead',
+				'zbsc_email'  => 'new.lead@example.test',
+				'zbsc_fname'  => 'Sam',
+				'zbsc_lname'  => 'Nolan',
+			)
+		);
+
+		$this->assertGreaterThan( 0, $contact_id, 'A form submission should still capture a brand new lead.' );
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( 'Sam', $contact['fname'], 'A new lead should keep the name it was captured with.' );
+		$this->assertSame( 'Lead', $contact['status'], 'A new lead should keep the status it was captured with.' );
+	}
+
+	/**
+	 * @testdox Callers that do not pass the option are unaffected.
+	 */
+	#[TestDox( 'Callers that do not pass the option are unaffected.' )]
+	public function test_protection_is_opt_in() {
+		global $zbs;
+
+		$contact_id = $this->create_tidied_contact();
+
+		$zbs->DAL->contacts->addUpdateContact(
+			array(
+				'data'                 => $this->self_reported_data(),
+				'do_not_update_blanks' => true,
+			)
+		);
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( 'alex', $contact['fname'], 'Callers that do not opt in should behave as they did before.' );
+	}
+}


### PR DESCRIPTION
**What**

Adds a `do_not_overwrite_populated` option to `addUpdateContact()`, and uses it for Woo Sync order imports and the lead capture form, so details people type about themselves fill in blank contact fields instead of replacing what is already there.

**Why**

Contacts are matched on email address. When Woo Sync imports an order, or the lead capture form takes a submission, we look up whichever contact holds that email and update it. That is the right thing to do, and I am not changing it.

What I did not like is what happens next. Everything typed at the checkout goes straight onto that contact, so a guest order replaces the name, address, city, postcode, country and phone number with whatever was in the billing fields. If a CRM user had tidied that record up by hand, the tidying is gone, and the next order does it again.

While I was in there I found a second one. The lead capture form passes `zbsc_status => 'Lead'` on every submission, so a contact already marked Customer drops back to Lead when they fill in a form. `$originalStatus` in `zeroBS_addUpdateCustomer()` looks like it was meant to prevent exactly that, but it is assigned once and never read.

**How**

A caller passes a list of field keys as `do_not_overwrite_populated`. For each one, if the contact already has a value we keep it, and if it is blank we fill it in. I hold the existing value rather than unsetting the key so it behaves the same whether or not the caller also passed `do_not_update_blanks`.

- Woo Sync passes the billing and shipping derived fields, but only for guest orders.
- All three lead form styles (`zbs_simple`, `zbs_naked`, `zbs_cgrab`) pass `status`, and the two that collect a name pass `fname` and `lname` too.

Orders from a logged-in WooCommerce customer are deliberately left alone. The account tells us whose details these are, so they keep updating as they always did. WooCommerce does the same thing internally, its analytics customer lookup (`CustomersScheduler::get_guest_id_by_email()`) only matches a guest order against rows with `user_id IS NULL`.

The option is opt-in, so every other caller behaves as before. Blank fields are still filled in, new contacts are still created, and email matching is untouched. The Woo Sync list can be adjusted or emptied with the `jpcrm_woosync_contact_fields_to_protect` filter, which restores the old behaviour for anyone who wants it.

**Testing**

`tests/php/entities/Contact_Field_Protection_Test.php`, 8 tests. Three of them fail on trunk and pass here:

- a populated name, address, phone and postcode survive an update from self-reported details
- a form submission does not replace a name already on record
- a form submission does not move a Customer back to Lead

The rest cover the behaviour I did not want to change: blank fields still get filled, fields outside the list still update, new contacts are still created with everything supplied, and callers that do not pass the option are unaffected.

Full suite is green, 50 tests, 221 assertions.

**Notes**

I have not run a real guest order through WooCommerce end to end, since Woo is not installed in the test environment. The guest branch is covered at the DAL level and I checked `import_crm_object_data()` by reading it, but it is worth someone clicking through an actual checkout before this ships.

The field lists are a judgement call. I went with the billing and shipping fields for Woo Sync and left `mobtel`, `worktel` and the custom fields out of it. Shout if you would draw that line somewhere else.

There is a related idea I have not done here: logging which fields an order changed on a contact, so there is a record rather than a silent update. That is additive and would be useful on its own, but it is a separate change.
