### PR TITLE
Stop forms clearing contact details, and updates clearing the owner

### DIFF
--- a/includes/ZeroBSCRM.AJAX.php
+++ b/includes/ZeroBSCRM.AJAX.php
@@ -1435,11 +1435,16 @@ function zbs_lead_form_capture() {
 			// TO LATER DO:
 			// COMBINE THE FOLLOWING RETRIEVES... no need to have separate input gathering...
 
+			// Every style submits the same email field, and the blanks decision hangs
+			// on nothing else, so both are resolved once for all the cases below. A
+			// style added later cannot silently miss the decision.
+			$zbs_email            = sanitize_email( wp_unslash( $_POST['zbs_email'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$do_not_update_blanks = jpcrm_form_capture_do_not_update_blanks( $zbs_email );
+
 			switch ( $zbs_form_style ) {
 
 				case 'zbs_simple':
 					// simple just has email
-					$zbs_email = sanitize_email( wp_unslash( $_POST['zbs_email'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 					// have added a new 'form' for 'externals'
 					$cID = zeroBS_integrations_addOrUpdateCustomer(
 						'form',
@@ -1464,7 +1469,7 @@ function zbs_lead_form_capture() {
 						// } This endpoint takes submissions from anyone, against any email address,
 						// } so a submission must not reset the status of an existing contact.
 						array( 'status' ),
-						jpcrm_form_capture_do_not_update_blanks( $zbs_email )
+						$do_not_update_blanks
 					);
 
 					// 2.97.7 - added this:
@@ -1496,7 +1501,6 @@ function zbs_lead_form_capture() {
 					// } Naked only has name + email?
 
 					// validate these...  (use functions in form save down...)
-					$zbs_email = sanitize_email( wp_unslash( $_POST['zbs_email'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 					$zbs_fname = sanitize_text_field( $_POST['zbs_fname'] );
 					// $zbs_lname = sanitize_text_field($_POST['zbs_lname']);
 					// $zbs_notes = "Customer Form Submit Message:\r\n===========\r\n".sanitize_text_field($_POST['zbs_notes'])."\r\n===========\r\n";
@@ -1528,13 +1532,12 @@ function zbs_lead_form_capture() {
 						// } This endpoint takes submissions from anyone, against any email address,
 						// } so a submission may fill these in on an existing contact but not replace them.
 						array( 'fname', 'status' ),
-						jpcrm_form_capture_do_not_update_blanks( $zbs_email )
+						$do_not_update_blanks
 					);
 
 					break;
 				case 'zbs_cgrab':
 					// validate these...  (use functions in form save down...)
-					$zbs_email = sanitize_email( wp_unslash( $_POST['zbs_email'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 					$zbs_fname = sanitize_text_field( $_POST['zbs_fname'] );
 					$zbs_lname = sanitize_text_field( $_POST['zbs_lname'] );
 					// Raw: $zbs_notes = "Customer Form Submit Message:\r\n===========\r\n".zeroBSCRM_textProcess($_POST['zbs_notes'])."\r\n===========\r\n";
@@ -1577,7 +1580,7 @@ function zbs_lead_form_capture() {
 						// } This endpoint takes submissions from anyone, against any email address,
 						// } so a submission may fill these in on an existing contact but not replace them.
 						array( 'fname', 'lname', 'status' ),
-						jpcrm_form_capture_do_not_update_blanks( $zbs_email )
+						$do_not_update_blanks
 					);
 
 					// 2.97.7 - added this:

--- a/includes/ZeroBSCRM.AJAX.php
+++ b/includes/ZeroBSCRM.AJAX.php
@@ -1185,6 +1185,41 @@ function zbs_lead_form_views() {
 	add_action( 'wp_ajax_nopriv_zbs_lead_form_views', 'zbs_lead_form_views' );
 	add_action( 'wp_ajax_zbs_lead_form_views', 'zbs_lead_form_views' );
 
+/**
+ * Whether a lead capture submission should leave blank fields alone.
+ *
+ * A lead capture form collects a name and an email address. It sends those to
+ * `addUpdateContact()` inside a full set of contact fields, everything else
+ * blank, so a submission matching an existing contact empties that contact's
+ * address, telephone numbers and social fields unless it is told not to.
+ *
+ * Nobody asked for that. The form has no input for any of those fields, so a
+ * blank arriving from it is an absence rather than an instruction, whoever
+ * submitted it. We always keep what is on record.
+ *
+ * This ignores the "Overwrite Option" setting, which otherwise decides this for
+ * every non-manual source. The setting still governs the API and the rest,
+ * where a caller sending a blank may well mean it. A public form is a different
+ * proposition: it takes submissions from anyone, against any email address.
+ *
+ * @param string $submitted_email The email address the form was submitted with.
+ *
+ * @return bool Whether blank fields should be left as they are.
+ */
+function jpcrm_form_capture_do_not_update_blanks( $submitted_email ) {
+
+	/**
+	 * Filters whether a lead capture submission leaves blank fields alone.
+	 *
+	 * Return false to let a submission clear the fields it did not send, which
+	 * is how this behaved on a site with "Overwrite Option" unticked.
+	 *
+	 * @param bool   $do_not_update_blanks Whether to leave blank fields as they are.
+	 * @param string $submitted_email      The email address the form was submitted with.
+	 */
+	return (bool) apply_filters( 'jpcrm_form_capture_do_not_update_blanks', true, $submitted_email );
+}
+
 	// } Handle form submissions interesting to see how this works cross domain...
 function zbs_lead_form_capture() {
 	/**
@@ -1425,7 +1460,8 @@ function zbs_lead_form_capture() {
 						'zbsc_',
 						// } This endpoint takes submissions from anyone, against any email address,
 						// } so a submission must not reset the status of an existing contact.
-						array( 'status' )
+						array( 'status' ),
+						jpcrm_form_capture_do_not_update_blanks( $zbs_email )
 					);
 
 					// 2.97.7 - added this:
@@ -1488,7 +1524,8 @@ function zbs_lead_form_capture() {
 						'zbsc_',
 						// } This endpoint takes submissions from anyone, against any email address,
 						// } so a submission may fill these in on an existing contact but not replace them.
-						array( 'fname', 'status' )
+						array( 'fname', 'status' ),
+						jpcrm_form_capture_do_not_update_blanks( $zbs_email )
 					);
 
 					break;
@@ -1536,7 +1573,8 @@ function zbs_lead_form_capture() {
 						'zbsc_',
 						// } This endpoint takes submissions from anyone, against any email address,
 						// } so a submission may fill these in on an existing contact but not replace them.
-						array( 'fname', 'lname', 'status' )
+						array( 'fname', 'lname', 'status' ),
+						jpcrm_form_capture_do_not_update_blanks( $zbs_email )
 					);
 
 					// 2.97.7 - added this:

--- a/includes/ZeroBSCRM.AJAX.php
+++ b/includes/ZeroBSCRM.AJAX.php
@@ -1214,6 +1214,9 @@ function jpcrm_form_capture_do_not_update_blanks( $submitted_email ) {
 	 * Return false to let a submission clear the fields it did not send, which
 	 * is how this behaved on a site with "Overwrite Option" unticked.
 	 *
+	 * It restores the blanking and nothing else. A submission still leaves the
+	 * contact assigned to whoever owns it.
+	 *
 	 * @param bool   $do_not_update_blanks Whether to leave blank fields as they are.
 	 * @param string $submitted_email      The email address the form was submitted with.
 	 */

--- a/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -1782,7 +1782,8 @@ function zeroBS_addUpdateCustomer(
 	$automatorPassthrough = false,
 	$owner = -1,
 	$metaBuilderPrefix = 'zbsc_',
-	$do_not_overwrite_populated = array()
+	$do_not_overwrite_populated = array(),
+	$do_not_update_blanks = false
 ) {
 
 	#} return
@@ -1962,6 +1963,7 @@ function zeroBS_addUpdateCustomer(
 				'automatorPassthrough'       => $automatorPassthrough,
 				'fallBackLog'                => $fallBackLog,
 				'do_not_overwrite_populated' => $do_not_overwrite_populated,
+				'do_not_update_blanks'       => $do_not_update_blanks,
 			)
 		);
 

--- a/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
+++ b/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
@@ -2975,6 +2975,23 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 				// is update
 				$update = true;
 
+				// Only write the owner when the caller named one.
+				//
+				// -1 is the default, and it means "not specified" rather than
+				// "unassign": nothing sets an owner through this path. Both
+				// setContactOwner() and the ownership box on the contact edit
+				// screen refuse anything below 1. But this path writes every
+				// column, so a caller updating a contact without naming an owner,
+				// which is most of them, cleared whoever the contact was assigned
+				// to. A lead capture submission and a client portal profile save
+				// both did it.
+				//
+				// An insert still writes it. A new contact needs the column set,
+				// and -1 is what an unowned contact holds.
+				if ( (int) $owner <= 0 ) {
+					unset( $dataArr['zbs_owner'] );
+					array_shift( $typeArr ); // the owner is the first type built above.
+				}
 			} else {
 
 				// INSERT (get's few extra :D)

--- a/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
+++ b/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
@@ -3055,6 +3055,23 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 				)
 			) !== false ) {
 
+				// externalSources, outside the limitedFields check below.
+				//
+				// Where a contact came from is worth recording whether or not the caller
+				// sent a full set of fields, and a caller that sends none is the norm now
+				// that `do_not_update_blanks` converts a form submission to limitedFields.
+				// Skipping this here lost the 'form' source on every existing contact that
+				// filled a form in.
+				//
+				// Passing no sources is a no-op: this adds and updates, never removes.
+				$this->DAL()->addUpdateExternalSources(
+					array(
+						'obj_id'           => $id,
+						'obj_type_id'      => ZBS_TYPE_CONTACT,
+						'external_sources' => isset( $data['externalSources'] ) ? $data['externalSources'] : array(),
+					)
+				);
+
 				// if passing limitedFields instead of data, we ignore the following
 				// this doesn't work, because data is in args default as arr
 				// if (isset($data) && is_array($data)){
@@ -3073,15 +3090,6 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 						);
 
 					}
-
-					// externalSources
-					$approvedExternalSource = $this->DAL()->addUpdateExternalSources(
-						array(
-							'obj_id'           => $id,
-							'obj_type_id'      => ZBS_TYPE_CONTACT,
-							'external_sources' => isset( $data['externalSources'] ) ? $data['externalSources'] : array(),
-						)
-					); // for IA below
 
 					// co's work?
 					// OBJ LINKS - to companies (1liner now as genericified)

--- a/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
+++ b/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
@@ -2895,7 +2895,8 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 			// UPDATE
 			$dataArr = array(
 
-				'zbs_owner'        => $owner,
+				// ownership
+				// 'zbs_owner' => $owner, // appended below: on update only when the caller named one.
 
 				// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- to be refactored.
 				// fields
@@ -2937,7 +2938,7 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 			$typeArr = array( // field data types
 				// '%d',  // site
 				// '%d',  // team
-				'%d',    // owner
+				// '%d',  // owner, appended below.
 				'%s',
 				'%s',
 				'%s',
@@ -2975,7 +2976,8 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 				// is update
 				$update = true;
 
-				// Only write the owner when the caller named one.
+				// Only write the owner when the caller named one, as the
+				// companies DAL does.
 				//
 				// -1 is the default, and it means "not specified" rather than
 				// "unassign": nothing sets an owner through this path. Both
@@ -2985,12 +2987,9 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 				// which is most of them, cleared whoever the contact was assigned
 				// to. A lead capture submission and a client portal profile save
 				// both did it.
-				//
-				// An insert still writes it. A new contact needs the column set,
-				// and -1 is what an unowned contact holds.
-				if ( (int) $owner <= 0 ) {
-					unset( $dataArr['zbs_owner'] );
-					array_shift( $typeArr ); // the owner is the first type built above.
+				if ( (int) $owner > 0 ) {
+					$dataArr['zbs_owner'] = $owner;
+					$typeArr[]            = '%d';
 				}
 			} else {
 
@@ -3000,6 +2999,11 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 				$typeArr[]           = '%d';
 				$dataArr['zbs_team'] = zeroBSCRM_team();
 				$typeArr[]           = '%d';
+
+				// A new contact needs the column set, and -1 is what an unowned
+				// contact holds.
+				$dataArr['zbs_owner'] = $owner;
+				$typeArr[]            = '%d';
 
 				if ( isset( $data['created'] ) && ! empty( $data['created'] ) && $data['created'] !== -1 ) {
 					$dataArr['zbsc_created'] = $data['created'];

--- a/includes/ZeroBSCRM.IntegrationFuncs.php
+++ b/includes/ZeroBSCRM.IntegrationFuncs.php
@@ -214,7 +214,7 @@ function zeroBS_integrations_getCustomer( $externalSource = '', $externalID = ''
 	|   False (boolean) (customer create/update failed)
 	|=======================================
 */
-function zeroBS_integrations_addOrUpdateCustomer( $externalSource = '', $externalID = '', $customerFields = array(), $customerDate = '', $fallbackLog = 'auto', $extraMeta = false, $automatorPassthroughArray = false, $emailAlreadyExistsAction = 'update', $fieldPrefix = 'zbsc_', $do_not_overwrite_populated = array() ) {
+function zeroBS_integrations_addOrUpdateCustomer( $externalSource = '', $externalID = '', $customerFields = array(), $customerDate = '', $fallbackLog = 'auto', $extraMeta = false, $automatorPassthroughArray = false, $emailAlreadyExistsAction = 'update', $fieldPrefix = 'zbsc_', $do_not_overwrite_populated = array(), $do_not_update_blanks = false ) {
 
 	#} leave this true and it'll run as normal.
 	$usualUpdate = true;
@@ -319,7 +319,7 @@ function zeroBS_integrations_addOrUpdateCustomer( $externalSource = '', $externa
 
 			#} Brutal add/update
 			#} MS - 3rd Jan 2019 - this (eventually) just calls the usual _addUpdateCustomer function
-			$customerID = zeroBS_addUpdateCustomer( $potentialCustomerID, $customerFields, $externalSource, $externalID, $customerDate, $fallbackLogToPass, $extraMeta, $automatorPassthrough, -1, $fieldPrefix, $do_not_overwrite_populated );
+			$customerID = zeroBS_addUpdateCustomer( $potentialCustomerID, $customerFields, $externalSource, $externalID, $customerDate, $fallbackLogToPass, $extraMeta, $automatorPassthrough, -1, $fieldPrefix, $do_not_overwrite_populated, $do_not_update_blanks );
 			return $customerID;
 
 		} #} / usual update

--- a/includes/ZeroBSCRM.IntegrationFuncs.php
+++ b/includes/ZeroBSCRM.IntegrationFuncs.php
@@ -214,7 +214,7 @@ function zeroBS_integrations_getCustomer( $externalSource = '', $externalID = ''
 	|   False (boolean) (customer create/update failed)
 	|=======================================
 */
-function zeroBS_integrations_addOrUpdateCustomer( $externalSource = '', $externalID = '', $customerFields = array(), $customerDate = '', $fallbackLog = 'auto', $extraMeta = false, $automatorPassthroughArray = false, $emailAlreadyExistsAction = 'update', $fieldPrefix = 'zbsc_', $do_not_overwrite_populated = array(), $do_not_update_blanks = false ) {
+function zeroBS_integrations_addOrUpdateCustomer( $externalSource = '', $externalID = '', $customerFields = array(), $customerDate = '', $fallbackLog = 'auto', $extraMeta = false, $automatorPassthroughArray = false, $emailAlreadyExistsAction = 'update', $fieldPrefix = 'zbsc_', $do_not_overwrite_populated = array(), $do_not_update_blanks = false ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, Squiz.Commenting.FunctionComment.WrongStyle -- legacy public API; renaming would break every caller.
 
 	#} leave this true and it'll run as normal.
 	$usualUpdate = true;
@@ -319,7 +319,7 @@ function zeroBS_integrations_addOrUpdateCustomer( $externalSource = '', $externa
 
 			#} Brutal add/update
 			#} MS - 3rd Jan 2019 - this (eventually) just calls the usual _addUpdateCustomer function
-			$customerID = zeroBS_addUpdateCustomer( $potentialCustomerID, $customerFields, $externalSource, $externalID, $customerDate, $fallbackLogToPass, $extraMeta, $automatorPassthrough, -1, $fieldPrefix, $do_not_overwrite_populated, $do_not_update_blanks );
+			$customerID = zeroBS_addUpdateCustomer( $potentialCustomerID, $customerFields, $externalSource, $externalID, $customerDate, $fallbackLogToPass, $extraMeta, $automatorPassthrough, -1, $fieldPrefix, $do_not_overwrite_populated, $do_not_update_blanks ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- legacy variable names from the surrounding function.
 			return $customerID;
 
 		} #} / usual update

--- a/tests/php/ajax/Invoice_Capability_Test.php
+++ b/tests/php/ajax/Invoice_Capability_Test.php
@@ -13,7 +13,6 @@
 namespace Automattic\Jetpack\CRM\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use WPDieException;
 
 /**
  * Capability gates on zbs_get_invoice_data and getinvs.
@@ -57,44 +56,6 @@ class Invoice_Capability_Test extends JPCRM_Base_Integration_TestCase {
 			'portal contact'  => array( 'zerobs_customer' ),
 			'subscriber'      => array( 'subscriber' ),
 		);
-	}
-
-	/**
-	 * Capture what a handler passes to wp_send_json* without exiting.
-	 *
-	 * Status codes are not checked here. wp_send_json() only sets one when
-	 * headers_sent() is false, which it never is under PHPUnit, so the response
-	 * body is the only thing actually observable.
-	 *
-	 * @param callable $handler The AJAX handler to invoke.
-	 * @return mixed The decoded response body.
-	 */
-	private function capture_json_response( callable $handler ) {
-		// wp_send_json() calls a bare die() unless wp_doing_ajax() is true, which
-		// would take the whole PHP process with it rather than throwing.
-		add_filter( 'wp_doing_ajax', '__return_true' );
-
-		$die_handler = static function () {
-			return static function () {
-				throw new WPDieException( 'sent' );
-			};
-		};
-		add_filter( 'wp_die_ajax_handler', $die_handler );
-		add_filter( 'wp_die_handler', $die_handler );
-
-		ob_start();
-		try {
-			$handler();
-		} catch ( WPDieException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			// Expected: wp_send_json always terminates.
-		}
-		$output = ob_get_clean();
-
-		remove_filter( 'wp_die_ajax_handler', $die_handler );
-		remove_filter( 'wp_die_handler', $die_handler );
-		remove_filter( 'wp_doing_ajax', '__return_true' );
-
-		return json_decode( $output, true );
 	}
 
 	/**

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -124,6 +124,7 @@ require $test_root . '/includes/bootstrap.php';
  */
 require_once JETPACK_CRM_TESTS_ROOT . '/class-jpcrm-base-testcase.php';
 require_once JETPACK_CRM_TESTS_ROOT . '/class-jpcrm-base-integration-testcase.php';
+require_once JETPACK_CRM_TESTS_ROOT . '/trait-jpcrm-lead-capture-form.php';
 
 /**
  * Load all feature flags, so they will be testable.

--- a/tests/php/class-jpcrm-base-integration-testcase.php
+++ b/tests/php/class-jpcrm-base-integration-testcase.php
@@ -86,4 +86,21 @@ abstract class JPCRM_Base_Integration_TestCase extends JPCRM_Base_TestCase {
 
 		return wp_create_user( 'testuser', 'password', 'user@demo.com' );
 	}
+
+	/**
+	 * Create a user who is allowed to own a contact.
+	 *
+	 * `addUpdateContact()` drops an owner who cannot, so a test that used a
+	 * default-role user (see `add_wp_user()`) would be asserting against -1
+	 * either way.
+	 *
+	 * @return int The new user ID.
+	 */
+	public function create_contact_owner(): int {
+		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		$this->assertTrue( user_can( $owner_id, 'admin_zerobs_usr' ), 'The owner under test cannot own a contact.' );
+
+		return $owner_id;
+	}
 }

--- a/tests/php/class-jpcrm-base-testcase.php
+++ b/tests/php/class-jpcrm-base-testcase.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack\CRM\Tests;
 
 use WP_UnitTestCase;
+use WPDieException;
 use ZeroBSCRM;
 
 /**
@@ -211,5 +212,45 @@ abstract class JPCRM_Base_TestCase extends WP_UnitTestCase {
 				'show_on_calendar' => false,
 			)
 		);
+	}
+
+	/**
+	 * Run an AJAX handler and return the JSON body it answered with.
+	 *
+	 * Handlers built on wp_send_json() write the response and exit, so the
+	 * output has to be buffered and the exit intercepted; the response body is
+	 * the only thing actually observable.
+	 *
+	 * @param callable $handler The AJAX handler to invoke.
+	 * @return mixed The decoded response body, or null where it was not JSON.
+	 */
+	protected function capture_json_response( callable $handler ) {
+		// wp_send_json() calls a bare die() unless wp_doing_ajax() is true, which
+		// would take the whole PHP process with it rather than throwing.
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$die_handler = static function () {
+			return static function () {
+				throw new WPDieException( 'sent' );
+			};
+		};
+		add_filter( 'wp_die_ajax_handler', $die_handler );
+		add_filter( 'wp_die_json_handler', $die_handler );
+		add_filter( 'wp_die_handler', $die_handler );
+
+		ob_start();
+		try {
+			$handler();
+		} catch ( WPDieException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Expected: wp_send_json always terminates.
+		}
+		$output = ob_get_clean();
+
+		remove_filter( 'wp_die_handler', $die_handler );
+		remove_filter( 'wp_die_json_handler', $die_handler );
+		remove_filter( 'wp_die_ajax_handler', $die_handler );
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+
+		return json_decode( $output, true );
 	}
 }

--- a/tests/php/entities/Contact_Field_Protection_Test.php
+++ b/tests/php/entities/Contact_Field_Protection_Test.php
@@ -19,12 +19,15 @@
 namespace Automattic\Jetpack\CRM\Entities\Tests;
 
 use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_TestCase;
+use Automattic\Jetpack\CRM\Tests\JPCRM_Lead_Capture_Form;
 use PHPUnit\Framework\Attributes\TestDox;
 
 /**
  * Test the populated-field protection used for self-reported contact details.
  */
 class Contact_Field_Protection_Test extends JPCRM_Base_Integration_TestCase {
+
+	use JPCRM_Lead_Capture_Form;
 
 	/**
 	 * Fields a self-reported source may fill in but not replace.
@@ -262,28 +265,6 @@ class Contact_Field_Protection_Test extends JPCRM_Base_Integration_TestCase {
 
 		$this->assertSame( 'Robin', $contact['fname'], 'A new contact should keep the details it was created with.' );
 		$this->assertSame( '1 Barrack Street', $contact['addr1'], 'A new contact should keep the details it was created with.' );
-	}
-
-	/**
-	 * Submit through the same helper, with the same arguments, the lead capture
-	 * endpoint uses for a 'zbs_cgrab' form.
-	 *
-	 * @param array $fields Contact fields, `zbsc_` prefixed as the endpoint passes them.
-	 * @return int|false The contact ID.
-	 */
-	private function submit_lead_form( array $fields ) {
-		return zeroBS_integrations_addOrUpdateCustomer(
-			'form',
-			$fields['zbsc_email'],
-			$fields,
-			'',
-			'none',
-			false,
-			false,
-			'update',
-			'zbsc_',
-			array( 'fname', 'lname', 'status' )
-		);
 	}
 
 	/**

--- a/tests/php/entities/Contact_Ownership_Test.php
+++ b/tests/php/entities/Contact_Ownership_Test.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Tests for what an update does to the user a contact is assigned to.
+ *
+ * `addUpdateContact()` takes an owner, defaulting to -1. Most callers never
+ * pass one, because most of them are updating fields and have no opinion about
+ * who the contact belongs to. The full update path writes every column, so
+ * that -1 used to land on the record and unassign it.
+ *
+ * @package Automattic\Jetpack\CRM
+ */
+
+namespace Automattic\Jetpack\CRM\Entities\Tests;
+
+use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Test that an update leaves the owner alone unless it is given one.
+ */
+class Contact_Ownership_Test extends JPCRM_Base_Integration_TestCase {
+
+	/**
+	 * Create a user who is allowed to own a contact.
+	 *
+	 * `addUpdateContact()` drops an owner who cannot, so a test that skipped
+	 * this would be asserting against -1 either way.
+	 *
+	 * @return int The new user ID.
+	 */
+	private function create_contact_owner(): int {
+		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		$this->assertTrue( user_can( $owner_id, 'admin_zerobs_usr' ), 'The owner under test cannot own a contact.' );
+
+		return $owner_id;
+	}
+
+	/**
+	 * An update that says nothing about ownership is the common case: the
+	 * client portal saving a profile, an integration syncing an address.
+	 *
+	 * @testdox An update that does not name an owner leaves the contact assigned.
+	 */
+	#[TestDox( 'An update that does not name an owner leaves the contact assigned.' )]
+	public function test_update_without_an_owner_keeps_the_owner() {
+		global $zbs;
+
+		$owner_id = $this->create_contact_owner();
+
+		$contact_id = $zbs->DAL->contacts->addUpdateContact(
+			array(
+				'owner' => $owner_id,
+				'data'  => $this->generate_contact_data( array( 'email' => 'alex.murphy@example.test' ) ),
+			)
+		);
+
+		$zbs->DAL->contacts->addUpdateContact(
+			array(
+				'id'   => $contact_id,
+				'data' => $this->generate_contact_data(
+					array(
+						'email' => 'alex.murphy@example.test',
+						'city'  => 'Cork',
+					)
+				),
+			)
+		);
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( $owner_id, (int) $contact['owner'], 'An update unassigned the contact.' );
+		$this->assertSame( 'Cork', $contact['city'], 'The update did not go through.' );
+	}
+
+	/**
+	 * @testdox An update that names an owner still assigns the contact.
+	 */
+	#[TestDox( 'An update that names an owner still assigns the contact.' )]
+	public function test_update_with_an_owner_still_assigns() {
+		global $zbs;
+
+		$first_owner_id  = $this->create_contact_owner();
+		$second_owner_id = $this->create_contact_owner();
+
+		$contact_id = $zbs->DAL->contacts->addUpdateContact(
+			array(
+				'owner' => $first_owner_id,
+				'data'  => $this->generate_contact_data( array( 'email' => 'alex.murphy@example.test' ) ),
+			)
+		);
+
+		$zbs->DAL->contacts->addUpdateContact(
+			array(
+				'id'    => $contact_id,
+				'owner' => $second_owner_id,
+				'data'  => $this->generate_contact_data( array( 'email' => 'alex.murphy@example.test' ) ),
+			)
+		);
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( $second_owner_id, (int) $contact['owner'], 'An update did not hand the contact over.' );
+	}
+
+	/**
+	 * The column is written on insert whatever happens, and -1 is what an
+	 * unowned contact holds.
+	 *
+	 * @testdox A new contact created without an owner is unowned.
+	 */
+	#[TestDox( 'A new contact created without an owner is unowned.' )]
+	public function test_new_contact_without_an_owner_is_unowned() {
+		global $zbs;
+
+		$contact_id = $zbs->DAL->contacts->addUpdateContact(
+			array(
+				'data' => $this->generate_contact_data( array( 'email' => 'sam.nolan@example.test' ) ),
+			)
+		);
+
+		$this->assertGreaterThan( 0, $contact_id, 'The contact was not created.' );
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( -1, (int) $contact['owner'], 'A contact created without an owner should be unowned.' );
+	}
+}

--- a/tests/php/entities/Contact_Ownership_Test.php
+++ b/tests/php/entities/Contact_Ownership_Test.php
@@ -21,22 +21,6 @@ use PHPUnit\Framework\Attributes\TestDox;
 class Contact_Ownership_Test extends JPCRM_Base_Integration_TestCase {
 
 	/**
-	 * Create a user who is allowed to own a contact.
-	 *
-	 * `addUpdateContact()` drops an owner who cannot, so a test that skipped
-	 * this would be asserting against -1 either way.
-	 *
-	 * @return int The new user ID.
-	 */
-	private function create_contact_owner(): int {
-		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
-
-		$this->assertTrue( user_can( $owner_id, 'admin_zerobs_usr' ), 'The owner under test cannot own a contact.' );
-
-		return $owner_id;
-	}
-
-	/**
 	 * An update that says nothing about ownership is the common case: the
 	 * client portal saving a profile, an integration syncing an address.
 	 *

--- a/tests/php/entities/Form_Capture_Blanking_Test.php
+++ b/tests/php/entities/Form_Capture_Blanking_Test.php
@@ -174,6 +174,36 @@ class Form_Capture_Blanking_Test extends JPCRM_Base_Integration_TestCase {
 	}
 
 	/**
+	 * A full update writes every column, and the owner is one of them. Nothing
+	 * on this path ever supplies one, so it was written back as -1 on every
+	 * submission and the contact came away unassigned. A limited field update
+	 * does not touch the column.
+	 *
+	 * @testdox A form submission does not unassign the contact it matches.
+	 */
+	#[TestDox( 'A form submission does not unassign the contact it matches.' )]
+	public function test_submission_does_not_unassign_the_contact() {
+		global $zbs;
+
+		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		$this->assertTrue( user_can( $owner_id, 'admin_zerobs_usr' ), 'The owner under test cannot own a contact.' );
+
+		$contact_id = $zbs->DAL->contacts->addUpdateContact(
+			array(
+				'owner' => $owner_id,
+				'data'  => $this->generate_contact_data( array( 'email' => self::CONTACT_EMAIL ) ),
+			)
+		);
+
+		$this->assertSame( $contact_id, $this->submit_lead_form( $this->cgrab_submission() ) );
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( $owner_id, (int) $contact['owner'], 'A form submission unassigned the contact.' );
+	}
+
+	/**
 	 * @testdox A form submission does not clear details the form never collected.
 	 */
 	#[TestDox( 'A form submission does not clear details the form never collected.' )]

--- a/tests/php/entities/Form_Capture_Blanking_Test.php
+++ b/tests/php/entities/Form_Capture_Blanking_Test.php
@@ -174,15 +174,11 @@ class Form_Capture_Blanking_Test extends JPCRM_Base_Integration_TestCase {
 	}
 
 	/**
-	 * A full update writes every column, and the owner is one of them. Nothing
-	 * on this path ever supplies one, so it was written back as -1 on every
-	 * submission and the contact came away unassigned. A limited field update
-	 * does not touch the column.
+	 * Create a contact assigned to somebody who is allowed to own one.
 	 *
-	 * @testdox A form submission does not unassign the contact it matches.
+	 * @return int[] The owner's user ID and the new contact ID.
 	 */
-	#[TestDox( 'A form submission does not unassign the contact it matches.' )]
-	public function test_submission_does_not_unassign_the_contact() {
+	private function create_owned_contact(): array {
 		global $zbs;
 
 		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
@@ -196,10 +192,53 @@ class Form_Capture_Blanking_Test extends JPCRM_Base_Integration_TestCase {
 			)
 		);
 
+		return array( $owner_id, $contact_id );
+	}
+
+	/**
+	 * Nothing on this path supplies an owner, and the full update path used to
+	 * write the -1 that stands for "not specified" into the column. So every
+	 * submission unassigned the contact it matched.
+	 *
+	 * @testdox A form submission does not unassign the contact it matches.
+	 */
+	#[TestDox( 'A form submission does not unassign the contact it matches.' )]
+	public function test_submission_does_not_unassign_the_contact() {
+		global $zbs;
+
+		list( $owner_id, $contact_id ) = $this->create_owned_contact();
+
 		$this->assertSame( $contact_id, $this->submit_lead_form( $this->cgrab_submission() ) );
 
 		$contact = $zbs->DAL->contacts->getContact( $contact_id );
 
+		$this->assertSame( $owner_id, (int) $contact['owner'], 'A form submission unassigned the contact.' );
+	}
+
+	/**
+	 * The filter is for a site that wants form blanks clearing fields again. It
+	 * is not for a site that wants its contacts unassigned, so the owner has to
+	 * survive the full update path the filter puts the submission back on.
+	 *
+	 * @testdox A form submission does not unassign the contact with the filter off.
+	 */
+	#[TestDox( 'A form submission does not unassign the contact with the filter off.' )]
+	public function test_submission_does_not_unassign_the_contact_with_the_filter_off() {
+		global $zbs;
+
+		list( $owner_id, $contact_id ) = $this->create_owned_contact();
+
+		add_filter( 'jpcrm_form_capture_do_not_update_blanks', '__return_false' );
+
+		try {
+			$this->assertSame( $contact_id, $this->submit_lead_form( $this->cgrab_submission() ) );
+		} finally {
+			remove_filter( 'jpcrm_form_capture_do_not_update_blanks', '__return_false' );
+		}
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( '', $contact['addr1'], 'The filter should still restore the blanking.' );
 		$this->assertSame( $owner_id, (int) $contact['owner'], 'A form submission unassigned the contact.' );
 	}
 

--- a/tests/php/entities/Form_Capture_Blanking_Test.php
+++ b/tests/php/entities/Form_Capture_Blanking_Test.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Tests for lead capture submissions clearing contact fields they did not send.
+ *
+ * A lead capture form collects a name and an email address, and the contact it
+ * matches on that address keeps whatever else is already recorded against it.
+ * Anything else is data loss triggered by a form anyone can fill in.
+ *
+ * @package Automattic\Jetpack\CRM
+ */
+
+namespace Automattic\Jetpack\CRM\Entities\Tests;
+
+use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_TestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Test that a form submission does not empty fields it never collected.
+ */
+class Form_Capture_Blanking_Test extends JPCRM_Base_Integration_TestCase {
+
+	/**
+	 * The email address both sides of each test share.
+	 *
+	 * @var string
+	 */
+	private const CONTACT_EMAIL = 'alex.murphy@example.test';
+
+	/**
+	 * Create a contact with details a CRM user has filled in by hand.
+	 *
+	 * None of these fields appear on a lead capture form.
+	 *
+	 * @param array $overrides Field overrides.
+	 * @return int The new contact ID.
+	 */
+	private function create_contact_with_details( array $overrides = array() ): int {
+		global $zbs;
+
+		$data = $this->generate_contact_data(
+			array_merge(
+				array(
+					'email'    => self::CONTACT_EMAIL,
+					'fname'    => 'Alex',
+					'lname'    => 'Murphy',
+					'addr1'    => '19 Prospect Hill',
+					'city'     => 'Cork',
+					'postcode' => 'T12 XY45',
+					'mobtel'   => '+353 87 000 0000',
+					'hometel'  => '+353 21 427 0000',
+				),
+				$overrides
+			)
+		);
+
+		$id = $zbs->DAL->contacts->addUpdateContact( array( 'data' => $data ) );
+
+		$this->assertGreaterThan( 0, $id, 'Failed to create the contact under test.' );
+
+		return $id;
+	}
+
+	/**
+	 * Submit through the same helper, with the same arguments, the lead capture
+	 * endpoint uses for a 'zbs_cgrab' form.
+	 *
+	 * @param array $fields Contact fields, `zbsc_` prefixed as the endpoint passes them.
+	 * @return int|false The contact ID.
+	 */
+	private function submit_lead_form( array $fields ) {
+		return zeroBS_integrations_addOrUpdateCustomer(
+			'form',
+			$fields['zbsc_email'],
+			$fields,
+			'',
+			'none',
+			false,
+			false,
+			'update',
+			'zbsc_',
+			array( 'fname', 'lname', 'status' ),
+			jpcrm_form_capture_do_not_update_blanks( $fields['zbsc_email'] )
+		);
+	}
+
+	/**
+	 * A submission carrying only what a 'zbs_cgrab' form collects.
+	 *
+	 * @return array
+	 */
+	private function cgrab_submission(): array {
+		return array(
+			'zbsc_status' => 'Lead',
+			'zbsc_email'  => self::CONTACT_EMAIL,
+			'zbsc_fname'  => 'Alex',
+			'zbsc_lname'  => 'Murphy',
+		);
+	}
+
+	/**
+	 * @testdox A form submission does not clear details the form never collected.
+	 */
+	#[TestDox( 'A form submission does not clear details the form never collected.' )]
+	public function test_submission_does_not_clear_unsent_fields() {
+		global $zbs;
+
+		$contact_id = $this->create_contact_with_details();
+
+		$this->submit_lead_form( $this->cgrab_submission() );
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( '19 Prospect Hill', $contact['addr1'], 'A form submission emptied the address.' );
+		$this->assertSame( 'Cork', $contact['city'], 'A form submission emptied the city.' );
+		$this->assertSame( 'T12 XY45', $contact['postcode'], 'A form submission emptied the postcode.' );
+		$this->assertSame( '+353 87 000 0000', $contact['mobtel'], 'A form submission emptied the mobile number.' );
+		$this->assertSame( '+353 21 427 0000', $contact['hometel'], 'A form submission emptied the telephone number.' );
+	}
+
+	/**
+	 * The whole point of lead capture is that a submission still records what it
+	 * did collect, and still fills in what is missing.
+	 *
+	 * @testdox A form submission still fills in details the contact is missing.
+	 */
+	#[TestDox( 'A form submission still fills in details the contact is missing.' )]
+	public function test_submission_still_fills_blank_fields() {
+		global $zbs;
+
+		$contact_id = $this->create_contact_with_details(
+			array(
+				'fname' => '',
+				'lname' => '',
+			)
+		);
+
+		$this->submit_lead_form( $this->cgrab_submission() );
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( 'Alex', $contact['fname'], 'A blank first name should still be filled in from a submission.' );
+		$this->assertSame( 'Murphy', $contact['lname'], 'A blank last name should still be filled in from a submission.' );
+		$this->assertSame( '19 Prospect Hill', $contact['addr1'], 'A form submission emptied the address.' );
+	}
+
+	/**
+	 * @testdox A form submission still captures a contact that does not exist yet.
+	 */
+	#[TestDox( 'A form submission still captures a contact that does not exist yet.' )]
+	public function test_submission_still_creates_new_contacts() {
+		global $zbs;
+
+		$contact_id = $this->submit_lead_form(
+			array(
+				'zbsc_status' => 'Lead',
+				'zbsc_email'  => 'new.lead@example.test',
+				'zbsc_fname'  => 'Sam',
+				'zbsc_lname'  => 'Nolan',
+			)
+		);
+
+		$this->assertGreaterThan( 0, $contact_id, 'A form submission should still capture a brand new lead.' );
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( 'Sam', $contact['fname'], 'A new lead should keep the name it was captured with.' );
+		$this->assertSame( 'Lead', $contact['status'], 'A new lead should keep the status it was captured with.' );
+	}
+
+	/**
+	 * The setting decides this for the API and every other non-manual source.
+	 * Forms no longer ask it, so leaving it at the default must not bring the
+	 * blanking back.
+	 *
+	 * @testdox The Overwrite Option setting does not re-enable blanking for forms.
+	 */
+	#[TestDox( 'The Overwrite Option setting does not re-enable blanking for forms.' )]
+	public function test_setting_does_not_re_enable_blanking() {
+		global $zbs;
+
+		$zbs->settings->update( 'fieldoverride', -1 );
+
+		$contact_id = $this->create_contact_with_details();
+
+		$this->submit_lead_form( $this->cgrab_submission() );
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( '19 Prospect Hill', $contact['addr1'], 'The default setting brought the blanking back.' );
+	}
+
+	/**
+	 * @testdox A site can restore the old behaviour through the filter.
+	 */
+	#[TestDox( 'A site can restore the old behaviour through the filter.' )]
+	public function test_filter_can_restore_blanking() {
+		global $zbs;
+
+		$contact_id = $this->create_contact_with_details();
+
+		add_filter( 'jpcrm_form_capture_do_not_update_blanks', '__return_false' );
+
+		try {
+			$this->submit_lead_form( $this->cgrab_submission() );
+		} finally {
+			remove_filter( 'jpcrm_form_capture_do_not_update_blanks', '__return_false' );
+		}
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( '', $contact['addr1'], 'The filter should be able to restore the old behaviour.' );
+	}
+
+	/**
+	 * @testdox The submitted email address is passed to the filter.
+	 */
+	#[TestDox( 'The submitted email address is passed to the filter.' )]
+	public function test_filter_receives_the_submitted_email() {
+
+		$seen = null;
+
+		$callback = static function ( $do_not_update_blanks, $submitted_email ) use ( &$seen ) {
+			$seen = $submitted_email;
+			return $do_not_update_blanks;
+		};
+
+		add_filter( 'jpcrm_form_capture_do_not_update_blanks', $callback, 10, 2 );
+
+		try {
+			jpcrm_form_capture_do_not_update_blanks( self::CONTACT_EMAIL );
+		} finally {
+			remove_filter( 'jpcrm_form_capture_do_not_update_blanks', $callback, 10 );
+		}
+
+		$this->assertSame( self::CONTACT_EMAIL, $seen, 'The filter should be given the address the form was submitted with.' );
+	}
+}

--- a/tests/php/entities/Form_Capture_Blanking_Test.php
+++ b/tests/php/entities/Form_Capture_Blanking_Test.php
@@ -12,12 +12,15 @@
 namespace Automattic\Jetpack\CRM\Entities\Tests;
 
 use Automattic\Jetpack\CRM\Tests\JPCRM_Base_Integration_TestCase;
+use Automattic\Jetpack\CRM\Tests\JPCRM_Lead_Capture_Form;
 use PHPUnit\Framework\Attributes\TestDox;
 
 /**
  * Test that a form submission does not empty fields it never collected.
  */
 class Form_Capture_Blanking_Test extends JPCRM_Base_Integration_TestCase {
+
+	use JPCRM_Lead_Capture_Form;
 
 	/**
 	 * The email address both sides of each test share.
@@ -61,29 +64,6 @@ class Form_Capture_Blanking_Test extends JPCRM_Base_Integration_TestCase {
 	}
 
 	/**
-	 * Submit through the same helper, with the same arguments, the lead capture
-	 * endpoint uses for a 'zbs_cgrab' form.
-	 *
-	 * @param array $fields Contact fields, `zbsc_` prefixed as the endpoint passes them.
-	 * @return int|false The contact ID.
-	 */
-	private function submit_lead_form( array $fields ) {
-		return zeroBS_integrations_addOrUpdateCustomer(
-			'form',
-			$fields['zbsc_email'],
-			$fields,
-			'',
-			'none',
-			false,
-			false,
-			'update',
-			'zbsc_',
-			array( 'fname', 'lname', 'status' ),
-			jpcrm_form_capture_do_not_update_blanks( $fields['zbsc_email'] )
-		);
-	}
-
-	/**
 	 * A submission carrying only what a 'zbs_cgrab' form collects.
 	 *
 	 * @return array
@@ -95,6 +75,102 @@ class Form_Capture_Blanking_Test extends JPCRM_Base_Integration_TestCase {
 			'zbsc_fname'  => 'Alex',
 			'zbsc_lname'  => 'Murphy',
 		);
+	}
+
+	/**
+	 * Post a submission to the endpoint in the given form style.
+	 *
+	 * Every style gets the whole payload. Each one reads the fields it collects
+	 * and ignores the rest, which is what a form of that style would send.
+	 *
+	 * @param string $style One of 'zbs_simple', 'zbs_naked', 'zbs_cgrab'.
+	 * @return array The decoded JSON response.
+	 */
+	private function submit_through_endpoint( string $style ): array {
+		return $this->submit_lead_capture_form(
+			array(
+				'zbs_form_id'    => (string) $this->create_lead_capture_form( $style ),
+				'zbs_form_style' => $style,
+				'zbs_email'      => self::CONTACT_EMAIL,
+				'zbs_fname'      => 'Alex',
+				'zbs_lname'      => 'Murphy',
+				'zbs_notes'      => 'Please get in touch.',
+			)
+		);
+	}
+
+	/**
+	 * Assert a submission through the endpoint left the contact's details alone.
+	 *
+	 * @param string $style One of 'zbs_simple', 'zbs_naked', 'zbs_cgrab'.
+	 * @return void
+	 */
+	private function assert_endpoint_keeps_unsent_fields( string $style ) {
+		global $zbs;
+
+		$contact_id = $this->create_contact_with_details();
+
+		$response = $this->submit_through_endpoint( $style );
+
+		$this->assertSame( 'success', $response['code'], 'The endpoint rejected the submission: ' . wp_json_encode( $response ) );
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( '19 Prospect Hill', $contact['addr1'], 'A submission emptied the address.' );
+		$this->assertSame( 'Cork', $contact['city'], 'A submission emptied the city.' );
+		$this->assertSame( 'T12 XY45', $contact['postcode'], 'A submission emptied the postcode.' );
+		$this->assertSame( '+353 87 000 0000', $contact['mobtel'], 'A submission emptied the mobile number.' );
+		$this->assertSame( '+353 21 427 0000', $contact['hometel'], 'A submission emptied the telephone number.' );
+	}
+
+	/**
+	 * Each form style passes its own arguments to the contacts DAL, so each one
+	 * has to be submitted for itself. These are the tests that would catch a
+	 * style added or edited without the option.
+	 *
+	 * @testdox A submission to the endpoint keeps unsent fields on a simple form.
+	 */
+	#[TestDox( 'A submission to the endpoint keeps unsent fields on a simple form.' )]
+	public function test_endpoint_keeps_unsent_fields_on_a_simple_form() {
+		$this->assert_endpoint_keeps_unsent_fields( 'zbs_simple' );
+	}
+
+	/**
+	 * @testdox A submission to the endpoint keeps unsent fields on a naked form.
+	 */
+	#[TestDox( 'A submission to the endpoint keeps unsent fields on a naked form.' )]
+	public function test_endpoint_keeps_unsent_fields_on_a_naked_form() {
+		$this->assert_endpoint_keeps_unsent_fields( 'zbs_naked' );
+	}
+
+	/**
+	 * @testdox A submission to the endpoint keeps unsent fields on a content grab form.
+	 */
+	#[TestDox( 'A submission to the endpoint keeps unsent fields on a content grab form.' )]
+	public function test_endpoint_keeps_unsent_fields_on_a_content_grab_form() {
+		$this->assert_endpoint_keeps_unsent_fields( 'zbs_cgrab' );
+	}
+
+	/**
+	 * Where a contact came from is recorded outside the fields, and a limited
+	 * field update used to skip it. Leaving blanks alone must not cost us the
+	 * record of the form that was filled in.
+	 *
+	 * @testdox A form submission still records the form as a source of the contact.
+	 */
+	#[TestDox( 'A form submission still records the form as a source of the contact.' )]
+	public function test_submission_records_the_form_as_a_source() {
+		global $zbs;
+
+		$contact_id = $this->create_contact_with_details();
+
+		$this->assertSame( $contact_id, $this->submit_lead_form( $this->cgrab_submission() ) );
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id, array( 'withExternalSources' => true ) );
+
+		$sources = wp_list_pluck( $contact['external_sources'], 'source' );
+
+		$this->assertContains( 'form', $sources, 'A form submission stopped recording where the contact came from.' );
 	}
 
 	/**

--- a/tests/php/entities/Form_Capture_Blanking_Test.php
+++ b/tests/php/entities/Form_Capture_Blanking_Test.php
@@ -38,9 +38,8 @@ class Form_Capture_Blanking_Test extends JPCRM_Base_Integration_TestCase {
 	 * @return int The new contact ID.
 	 */
 	private function create_contact_with_details( array $overrides = array() ): int {
-		global $zbs;
 
-		$data = $this->generate_contact_data(
+		$id = $this->add_contact(
 			array_merge(
 				array(
 					'email'    => self::CONTACT_EMAIL,
@@ -56,11 +55,28 @@ class Form_Capture_Blanking_Test extends JPCRM_Base_Integration_TestCase {
 			)
 		);
 
-		$id = $zbs->DAL->contacts->addUpdateContact( array( 'data' => $data ) );
-
 		$this->assertGreaterThan( 0, $id, 'Failed to create the contact under test.' );
 
 		return $id;
+	}
+
+	/**
+	 * Assert the hand-filled details from `create_contact_with_details()` are
+	 * still on the contact, one assertion per field a form never collects.
+	 *
+	 * @param int $contact_id The contact to check.
+	 * @return void
+	 */
+	private function assert_contact_details_intact( int $contact_id ) {
+		global $zbs;
+
+		$contact = $zbs->DAL->contacts->getContact( $contact_id );
+
+		$this->assertSame( '19 Prospect Hill', $contact['addr1'], 'A submission emptied the address.' );
+		$this->assertSame( 'Cork', $contact['city'], 'A submission emptied the city.' );
+		$this->assertSame( 'T12 XY45', $contact['postcode'], 'A submission emptied the postcode.' );
+		$this->assertSame( '+353 87 000 0000', $contact['mobtel'], 'A submission emptied the mobile number.' );
+		$this->assertSame( '+353 21 427 0000', $contact['hometel'], 'A submission emptied the telephone number.' );
 	}
 
 	/**
@@ -106,7 +122,6 @@ class Form_Capture_Blanking_Test extends JPCRM_Base_Integration_TestCase {
 	 * @return void
 	 */
 	private function assert_endpoint_keeps_unsent_fields( string $style ) {
-		global $zbs;
 
 		$contact_id = $this->create_contact_with_details();
 
@@ -114,13 +129,7 @@ class Form_Capture_Blanking_Test extends JPCRM_Base_Integration_TestCase {
 
 		$this->assertSame( 'success', $response['code'], 'The endpoint rejected the submission: ' . wp_json_encode( $response ) );
 
-		$contact = $zbs->DAL->contacts->getContact( $contact_id );
-
-		$this->assertSame( '19 Prospect Hill', $contact['addr1'], 'A submission emptied the address.' );
-		$this->assertSame( 'Cork', $contact['city'], 'A submission emptied the city.' );
-		$this->assertSame( 'T12 XY45', $contact['postcode'], 'A submission emptied the postcode.' );
-		$this->assertSame( '+353 87 000 0000', $contact['mobtel'], 'A submission emptied the mobile number.' );
-		$this->assertSame( '+353 21 427 0000', $contact['hometel'], 'A submission emptied the telephone number.' );
+		$this->assert_contact_details_intact( $contact_id );
 	}
 
 	/**
@@ -181,9 +190,7 @@ class Form_Capture_Blanking_Test extends JPCRM_Base_Integration_TestCase {
 	private function create_owned_contact(): array {
 		global $zbs;
 
-		$owner_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
-
-		$this->assertTrue( user_can( $owner_id, 'admin_zerobs_usr' ), 'The owner under test cannot own a contact.' );
+		$owner_id = $this->create_contact_owner();
 
 		$contact_id = $zbs->DAL->contacts->addUpdateContact(
 			array(
@@ -247,19 +254,12 @@ class Form_Capture_Blanking_Test extends JPCRM_Base_Integration_TestCase {
 	 */
 	#[TestDox( 'A form submission does not clear details the form never collected.' )]
 	public function test_submission_does_not_clear_unsent_fields() {
-		global $zbs;
 
 		$contact_id = $this->create_contact_with_details();
 
 		$this->submit_lead_form( $this->cgrab_submission() );
 
-		$contact = $zbs->DAL->contacts->getContact( $contact_id );
-
-		$this->assertSame( '19 Prospect Hill', $contact['addr1'], 'A form submission emptied the address.' );
-		$this->assertSame( 'Cork', $contact['city'], 'A form submission emptied the city.' );
-		$this->assertSame( 'T12 XY45', $contact['postcode'], 'A form submission emptied the postcode.' );
-		$this->assertSame( '+353 87 000 0000', $contact['mobtel'], 'A form submission emptied the mobile number.' );
-		$this->assertSame( '+353 21 427 0000', $contact['hometel'], 'A form submission emptied the telephone number.' );
+		$this->assert_contact_details_intact( $contact_id );
 	}
 
 	/**

--- a/tests/php/trait-jpcrm-lead-capture-form.php
+++ b/tests/php/trait-jpcrm-lead-capture-form.php
@@ -58,7 +58,7 @@ trait JPCRM_Lead_Capture_Form {
 	 * @return array The decoded JSON response.
 	 */
 	protected function submit_lead_capture_form( array $post ): array {
-		$original_post = $_POST;
+		$original_post = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- simulating the public form endpoint, which has no nonce by design.
 
 		$_POST = array_merge(
 			array(

--- a/tests/php/trait-jpcrm-lead-capture-form.php
+++ b/tests/php/trait-jpcrm-lead-capture-form.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Shared fixtures for the lead capture form endpoint.
+ *
+ * @package Automattic\Jetpack\CRM
+ */
+
+namespace Automattic\Jetpack\CRM\Tests;
+
+use WPDieException;
+
+/**
+ * Ways to put a submission through `zbs_lead_form_capture()`.
+ *
+ * The endpoint's argument list to the contacts DAL lives here once. It has
+ * grown twice recently, and a second copy that falls behind stops testing the
+ * thing it claims to.
+ */
+trait JPCRM_Lead_Capture_Form {
+
+	/**
+	 * Create a form for a submission to arrive against.
+	 *
+	 * The endpoint counts a conversion against the form it was given, so the
+	 * form has to exist.
+	 *
+	 * @param string $style One of 'zbs_simple', 'zbs_naked', 'zbs_cgrab'.
+	 * @return int The new form ID.
+	 */
+	protected function create_lead_capture_form( string $style = 'zbs_cgrab' ): int {
+		global $zbs;
+
+		$form_id = $zbs->DAL->forms->addUpdateForm(
+			array(
+				'data' => array(
+					'title'       => 'Newsletter signup',
+					'style'       => $style,
+					'views'       => 0,
+					'conversions' => 0,
+				),
+			)
+		);
+
+		$this->assertGreaterThan( 0, $form_id, 'Failed to create the form under test.' );
+
+		return $form_id;
+	}
+
+	/**
+	 * Put a submission through the endpoint itself.
+	 *
+	 * `zbs_lead_form_capture()` reads `$_POST` and ends the request with
+	 * `wp_send_json()`, so this fills in the one and catches the other. Going
+	 * through the endpoint is the point: it is the only way to cover the
+	 * arguments each form style passes to the contacts DAL.
+	 *
+	 * @param array $post The submitted fields, on top of a valid empty submission.
+	 * @return array The decoded JSON response.
+	 */
+	protected function submit_lead_capture_form( array $post ): array {
+		$original_post = $_POST;
+
+		$_POST = array_merge(
+			array(
+				// The honeypot is hidden from humans, so a real submission leaves it blank.
+				'zbs_hpot_email' => '',
+				'zbs_form_style' => 'zbs_cgrab',
+				'zbs_notes'      => '',
+			),
+			$post
+		);
+
+		// `wp_send_json()` calls `die` outright unless this is an AJAX request,
+		// and `wp_die()` picks its handler the same way. WPDieException is what
+		// the WordPress test suite throws in place of the exit.
+		$throw = static function () {
+			throw new WPDieException();
+		};
+
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', $throw );
+		add_filter( 'wp_die_json_handler', $throw );
+		add_filter( 'wp_die_handler', $throw );
+
+		// The response is written straight out, and the suite fails a test that prints.
+		ob_start();
+
+		try {
+			zbs_lead_form_capture();
+		} catch ( WPDieException $e ) {
+			// The endpoint answered. That is it returning, not a failure.
+			unset( $e );
+		} finally {
+			$response = ob_get_clean();
+
+			remove_filter( 'wp_die_handler', $throw );
+			remove_filter( 'wp_die_json_handler', $throw );
+			remove_filter( 'wp_die_ajax_handler', $throw );
+			remove_filter( 'wp_doing_ajax', '__return_true' );
+
+			$_POST = $original_post;
+		}
+
+		$decoded = json_decode( $response, true );
+
+		$this->assertIsArray( $decoded, 'The endpoint did not answer with JSON: ' . $response );
+
+		return $decoded;
+	}
+
+	/**
+	 * Call the contacts DAL with the arguments the endpoint passes for a
+	 * 'zbs_cgrab' form.
+	 *
+	 * Quicker than the endpoint, and enough where the test is about what the
+	 * DAL does with those arguments rather than about which ones it is sent.
+	 *
+	 * @param array $fields Contact fields, `zbsc_` prefixed as the endpoint passes them.
+	 * @return int|false The contact ID.
+	 */
+	protected function submit_lead_form( array $fields ) {
+		return zeroBS_integrations_addOrUpdateCustomer(
+			'form',
+			$fields['zbsc_email'],
+			$fields,
+			'',
+			'none',
+			false,
+			false,
+			'update',
+			'zbsc_',
+			array( 'fname', 'lname', 'status' ),
+			jpcrm_form_capture_do_not_update_blanks( $fields['zbsc_email'] )
+		);
+	}
+}

--- a/tests/php/trait-jpcrm-lead-capture-form.php
+++ b/tests/php/trait-jpcrm-lead-capture-form.php
@@ -7,8 +7,6 @@
 
 namespace Automattic\Jetpack\CRM\Tests;
 
-use WPDieException;
-
 /**
  * Ways to put a submission through `zbs_lead_form_capture()`.
  *
@@ -49,10 +47,10 @@ trait JPCRM_Lead_Capture_Form {
 	/**
 	 * Put a submission through the endpoint itself.
 	 *
-	 * `zbs_lead_form_capture()` reads `$_POST` and ends the request with
-	 * `wp_send_json()`, so this fills in the one and catches the other. Going
-	 * through the endpoint is the point: it is the only way to cover the
-	 * arguments each form style passes to the contacts DAL.
+	 * `zbs_lead_form_capture()` reads `$_POST`, so this fills it in and hands
+	 * the exit-and-answer part to `capture_json_response()`. Going through the
+	 * endpoint is the point: it is the only way to cover the arguments each
+	 * form style passes to the contacts DAL.
 	 *
 	 * @param array $post The submitted fields, on top of a valid empty submission.
 	 * @return array The decoded JSON response.
@@ -70,40 +68,13 @@ trait JPCRM_Lead_Capture_Form {
 			$post
 		);
 
-		// `wp_send_json()` calls `die` outright unless this is an AJAX request,
-		// and `wp_die()` picks its handler the same way. WPDieException is what
-		// the WordPress test suite throws in place of the exit.
-		$throw = static function () {
-			throw new WPDieException();
-		};
-
-		add_filter( 'wp_doing_ajax', '__return_true' );
-		add_filter( 'wp_die_ajax_handler', $throw );
-		add_filter( 'wp_die_json_handler', $throw );
-		add_filter( 'wp_die_handler', $throw );
-
-		// The response is written straight out, and the suite fails a test that prints.
-		ob_start();
-
 		try {
-			zbs_lead_form_capture();
-		} catch ( WPDieException $e ) {
-			// The endpoint answered. That is it returning, not a failure.
-			unset( $e );
+			$decoded = $this->capture_json_response( 'zbs_lead_form_capture' );
 		} finally {
-			$response = ob_get_clean();
-
-			remove_filter( 'wp_die_handler', $throw );
-			remove_filter( 'wp_die_json_handler', $throw );
-			remove_filter( 'wp_die_ajax_handler', $throw );
-			remove_filter( 'wp_doing_ajax', '__return_true' );
-
 			$_POST = $original_post;
 		}
 
-		$decoded = json_decode( $response, true );
-
-		$this->assertIsArray( $decoded, 'The endpoint did not answer with JSON: ' . $response );
+		$this->assertIsArray( $decoded, 'The endpoint did not answer with JSON.' );
 
 		return $decoded;
 	}


### PR DESCRIPTION
Fixes #31.

Two fixes here. The first is what #31 asked for. The second is a bug in `addUpdateContact()` that review turned up while checking the first, and it is not about forms at all.

## A form submission does not keep fields it did not send

A lead capture form collects a name and an email address. The submission is matched to a contact on that address, which is what we want, but it arrives at `addUpdateContact()` as a full set of contact fields with everything else blank, so on a default install the details already on that contact are not preserved.

There is a setting for it. "Overwrite Option" in Field Options converts the blanks into a limited field update instead. It ships unticked, so the default is to lose the data.

The three form styles now pass `do_not_update_blanks` and keep what is on record. The forms have no input for any of the fields being emptied, so a blank arriving from one is an absence rather than an instruction.

Sites that already have the setting ticked see no change at all. `ZeroBSCRM.DAL3.Obj.Contacts.php:2803` only ever forces `do_not_update_blanks` to true, never to false, so the setting and the new argument cannot disagree.

### Why not change the setting instead

Two reasons.

Changing the default would not reach anyone. `WHWPConfigLib` persists defaults rather than falling back to them — `initCreate()` writes the whole set at install and `validateAndUpdate()` writes any missing key on every load (`includes/wh.config.lib.php:80` and `:90`). `fieldoverride` is already stored as `-1` on every existing site, so editing the default in `Config.Init.php` reaches new installs and nothing else.

And the setting is still right for the callers it was written for. It governs the API, CSV import and everything else non-manual, where a caller sending a blank may well mean it. A lead capture form is a different proposition, because it has no input for any of the fields in question, so there is no intention to honour.

So this changes the form endpoints and leaves the setting alone.

### How

`zeroBS_addUpdateCustomer()` and `zeroBS_integrations_addOrUpdateCustomer()` take a trailing `$do_not_update_blanks`, defaulting to `false`, and forward it. Same shape as the trailing argument #30 added a week ago. `addUpdateContact()` is unchanged — it has always accepted the option (`ZeroBSCRM.DAL3.Obj.Contacts.php:2523`); the setting merely forces it true for external sources.

The value comes from `jpcrm_form_capture_do_not_update_blanks()`, which exists for the filter of the same name. A site that relied on forms clearing fields can return `false` from it and get the old behaviour back without touching the site-wide setting.

### The external source, which I broke on the way

`do_not_update_blanks` converts the update to `limitedFields`, and `addUpdateContact()` skipped its external sources block whenever `limitedFields` was set. So routing forms through it stopped recording the 'form' source against contacts that already existed. Contacts a form created were unaffected, and matching still worked off the email address, but the Source row on the contact record stopped mentioning the form.

That call now sits outside the check. It only adds and updates, never removes, so a caller passing no sources leaves the record alone and the other limited field callers are unaffected.

### On the authenticated case

I considered allowing the blanking when the submitter is logged in to WordPress under the submitted address, on the grounds that WordPress has confirmed that address and the person is then updating their own record. I left it out.

It would almost never fire — lead capture submitters are rarely logged in — and when it did it would erase details the submitter had not asked to erase, because the form has no inputs for them. A branch with no beneficiary. The authenticated distinction belongs on the API path, where a deliberate blank is a real thing to express.

## An update clears the user the contact is assigned to

`addUpdateContact()` takes an owner defaulting to `-1`, and the full update path writes it to `zbs_owner` along with every other column (`:2898`). Most callers never name an owner, because most of them are updating fields and have no opinion about who the contact belongs to. That `-1` landed on the record and unassigned it.

`-1` there means "not specified" rather than "unassign". Nothing assigns a contact through this path: `setContactOwner()` refuses anything below 1, and so does the ownership box on the contact edit screen. So an update now writes `zbs_owner` only when the caller named one. An insert still writes it, because a new contact needs the column set and `-1` is what an unowned contact holds.

Who this was hurting:

- **The client portal.** A profile save goes through the same path with no owner and no form involved (`modules/portal/class-client-portal.php:289`), so a customer editing their own details unassigned their contact.
- **Lead capture.** Every submission did it, until the first fix above sent forms down the limited field update.
- The contact edit screen was fine. It passes the current owner back rather than leaving it at `-1`.
- Woo Sync and the WordPress user integration were fine too. Both take the limited field path already.

I first wrote the lead capture half of this up as a fix that came free with the blanking change. It was not free, and a second review caught why: it only held for the default path. A site returning `false` from the filter, which is advertised as restoring the blanking, went back to the full update path and lost the owner again. Fixing the write itself covers the filter path and the portal as well.

## Testing

`Form_Capture_Blanking_Test` in the existing `entities` suite, twelve tests:

- A submission does not clear details the form never collected.
- A submission still fills in details the contact is missing, which is most of the value of lead capture.
- A submission still captures a contact that does not exist yet.
- A submission still records the form as a source of the contact.
- A submission does not unassign the contact it matches, with the filter on and with it off.
- Leaving "Overwrite Option" at its default does not bring the blanking back.
- The filter restores the old behaviour.
- The filter is given the submitted address.
- A submission posted to the endpoint keeps unsent fields, once for each of the three form styles.

`Contact_Ownership_Test`, three more, because the owner fix is in the DAL and is not about forms:

- An update that does not name an owner leaves the contact assigned.
- An update that names an owner still assigns the contact.
- A new contact created without an owner is unowned.

The first tests went through a copy of the endpoint's call rather than the endpoint, so nothing covered the three call sites this changes. Drop the argument from any one of them and every test still passed. `submit_lead_capture_form()` now fills in `$_POST` and posts to `zbs_lead_form_capture()` itself, catching the exit `wp_send_json()` ends the request with. One test per form style, so a style added or edited without the option fails on its own.

I checked each new test fails without its fix rather than only passing with it:

- Put the external sources call back inside the `limitedFields` check and `test_submission_records_the_form_as_a_source` fails on `Failed asserting that an array contains 'form'`.
- Drop the argument from the `zbs_naked` call site and only the naked endpoint test fails, on `addr1`. Simple and content grab still pass.
- Take out the owner guard and both `test_update_without_an_owner_keeps_the_owner` and `test_submission_does_not_unassign_the_contact_with_the_filter_off` fail on `-1 is identical to` the owner. The other two ownership tests still pass, which is what I wanted: one covers the insert path and the other names an owner, so neither should depend on the guard.

The copy of the endpoint's call is down to one, shared with the #30 tests, whose own copy this branch had left a version behind. It lives in `tests/php/trait-jpcrm-lead-capture-form.php` and loads from `bootstrap.php`. `Contact_Ownership_Test` is a second new file in the same directory-globbed suite. So this adds no test suite and does not touch the phpunit configs. #29 and #33 both add one at the same insertion point and will conflict with each other; this stays out of that.

Full suite green: 66 tests, 291 assertions.

## To verify manually

Create a contact with an address and a mobile number, assign it to a user, and note the Source row on the record.

Put a lead capture form on a page, submit it with that contact's email address and any name.

Before: the address, city, postcode and phone numbers are empty, and the contact is no longer assigned to anyone. After: they are untouched, the assignment holds, the name still fills in if it was blank, and the Source row still lists the form.

Worth also submitting for an email address with no contact behind it, to confirm new leads are still captured.

For the ownership fix on its own, log in to the client portal as a contact assigned to someone and save the profile. Before: the contact comes away unassigned. After: it does not. Changing the owner on the contact edit screen should still work either way.

