### PR TITLE
Make the local lint and test commands work

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,7 @@ webpack.config.js     export-ignore
 babel.config.js       export-ignore
 codeception.dist.yml  export-ignore
 phpunit.*.xml.dist    export-ignore
+.phpcs.xml.dist       export-ignore
 AGENTS.md             export-ignore
 CLAUDE.md             export-ignore
 README.md             export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,14 @@
-/jetpack_vendor/
-/vendor/
-/node_modules/
+# No trailing slash on these three: `make worktree-link` puts a symlink here,
+# and a trailing slash matches directories only, so the links showed up as
+# untracked in every worktree.
+/jetpack_vendor
+/vendor
+/node_modules
 /build/
 /dist/
 /.cache/
 /.phpunit.cache/
-/.claude/
+/.claude/worktrees/
 **/css/**/*.css
 **/js/*.min.js
 **/js/*.min.js.LICENSE.txt

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,11 @@
 /dist/
 /.cache/
 /.phpunit.cache/
-/.claude/worktrees/
+# The whole directory, not just worktrees/. It is scratch space: worktrees are
+# the thing that would do real damage staged by a `git add -A`, but screenshots
+# and notes collect in there too, and narrowing this to worktrees/ put three of
+# them straight into `git status`.
+/.claude/
 **/css/**/*.css
 **/js/*.min.js
 **/js/*.min.js.LICENSE.txt

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /dist/
 /.cache/
 /.phpunit.cache/
+/.claude/
 **/css/**/*.css
 **/js/*.min.js
 **/js/*.min.js.LICENSE.txt

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -19,29 +19,36 @@
 	<arg name="parallel" value="10"/>
 	<arg name="extensions" value="php"/>
 
-	<!--
-		Every exclude below is `type="relative"`, anchored, and paired with this
-		basepath. The default is to match the pattern against the file's absolute
-		path, which breaks as soon as the checkout itself sits under a directory
-		that a pattern names. A worktree in `.claude/worktrees/` has `.claude/` in
-		every path within it, so an unanchored `./.claude/*` excluded the entire
-		worktree and lint passed there while looking at no files at all.
-	-->
+	<!-- Report paths relative to the repo root rather than from /Users/... -->
 	<arg name="basepath" value="."/>
 
 	<file>.</file>
 
-	<!-- Dependencies and build output. -->
-	<exclude-pattern type="relative">^vendor/</exclude-pattern>
-	<exclude-pattern type="relative">^jetpack_vendor/</exclude-pattern>
-	<exclude-pattern type="relative">^node_modules/</exclude-pattern>
-	<exclude-pattern type="relative">^build/</exclude-pattern>
-	<exclude-pattern type="relative">^dist/</exclude-pattern>
+	<!--
+		Exclude patterns are matched, unanchored, against each file's absolute path.
+		`type="relative"` is supposed to match against the path from basepath
+		instead; it does nothing here, and a pattern written that way silently
+		excludes nothing, so do not reach for it.
 
-	<!-- Not source: agent worktrees are whole second checkouts of this repo. -->
-	<exclude-pattern type="relative">^\.claude/</exclude-pattern>
+		The consequence is that a pattern cannot tell "this checkout's vendor/" from
+		"a checkout that happens to live under a vendor/". Fine for the directories
+		below, which we would never nest a checkout inside.
+	-->
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/jetpack_vendor/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/build/*</exclude-pattern>
+	<exclude-pattern>*/dist/*</exclude-pattern>
 
-	<exclude-pattern type="relative">^tests/</exclude-pattern>
+	<!--
+		There is deliberately no pattern for `.claude/`, which holds agent worktrees.
+		Those are whole second checkouts and a full-tree run should skip them, but a
+		worktree at `.claude/worktrees/x/` has `.claude/` in every path inside it, so
+		any pattern naming that directory excludes the worktree's own source too.
+		That is what happened: `make lint` in a worktree reported success having
+		linted nothing. A slow full-tree run is the better failure of the two, and
+		`git` never hands `.claude/` to phpcs-changed because it is untracked.
+	-->
 
 	<rule ref="WordPress-Core">
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
@@ -70,6 +77,42 @@
 				<element value="zero-bs-crm"/>
 			</property>
 		</properties>
+	</rule>
+
+	<!--
+		Test code is linted, but a handful of sniffs describe a plugin rather than a
+		test suite and would fail correct test code. Each one below is turned off for
+		`tests/` only, rather than dropping the whole tree the way this ruleset used
+		to. Everything else, docblocks included, applies there as it does anywhere.
+	-->
+
+	<!-- PHPUnit finds classes by file name: List_View_Permissions_Test.php, not class-*.php. -->
+	<rule ref="WordPress.Files.FileName">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
+
+	<!-- The test cases we extend expose properties we do not name: WP_Ajax_UnitTestCase::$_last_response, $zbs->DAL. -->
+	<rule ref="WordPress.NamingConventions.ValidVariableName">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
+
+	<!-- Nothing in a test renders to a browser, and an assertion message is not output. -->
+	<rule ref="WordPress.Security.EscapeOutput">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
+
+	<!-- Codeception's own API is camelCase and underscore-prefixed: tryToTest(), _before(). -->
+	<rule ref="WordPress.NamingConventions.ValidFunctionName">
+		<exclude-pattern>*/tests/codeception/*</exclude-pattern>
+	</rule>
+
+	<!--
+		A test's docblock is still required, but `@testdox` is its description. The
+		sniff wants a short description above the tags, which alongside the tag and
+		the `#[TestDox]` attribute would be the same sentence written three times.
+	-->
+	<rule ref="Generic.Commenting.DocComment.MissingShort">
+		<exclude-pattern>*/tests/*</exclude-pattern>
 	</rule>
 
 	<!-- WPCS 3.0 dropped its own WordPress.CodeAnalysis.EmptyStatement wrapper. -->

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -19,25 +19,50 @@
 	<arg name="parallel" value="10"/>
 	<arg name="extensions" value="php"/>
 
+	<!--
+		Every exclude below is `type="relative"`, anchored, and paired with this
+		basepath. The default is to match the pattern against the file's absolute
+		path, which breaks as soon as the checkout itself sits under a directory
+		that a pattern names. A worktree in `.claude/worktrees/` has `.claude/` in
+		every path within it, so an unanchored `./.claude/*` excluded the entire
+		worktree and lint passed there while looking at no files at all.
+	-->
+	<arg name="basepath" value="."/>
+
 	<file>.</file>
 
 	<!-- Dependencies and build output. -->
-	<exclude-pattern>./vendor/*</exclude-pattern>
-	<exclude-pattern>./jetpack_vendor/*</exclude-pattern>
-	<exclude-pattern>./node_modules/*</exclude-pattern>
-	<exclude-pattern>./build/*</exclude-pattern>
-	<exclude-pattern>./dist/*</exclude-pattern>
+	<exclude-pattern type="relative">^vendor/</exclude-pattern>
+	<exclude-pattern type="relative">^jetpack_vendor/</exclude-pattern>
+	<exclude-pattern type="relative">^node_modules/</exclude-pattern>
+	<exclude-pattern type="relative">^build/</exclude-pattern>
+	<exclude-pattern type="relative">^dist/</exclude-pattern>
 
 	<!-- Not source: agent worktrees are whole second checkouts of this repo. -->
-	<exclude-pattern>./.claude/*</exclude-pattern>
+	<exclude-pattern type="relative">^\.claude/</exclude-pattern>
 
-	<exclude-pattern>./tests/*</exclude-pattern>
+	<exclude-pattern type="relative">^tests/</exclude-pattern>
 
 	<rule ref="WordPress-Core">
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
 	</rule>
 
 	<rule ref="WordPress-Docs"/>
+
+	<!--
+		Restored from phpcs.security.xml.dist, the second ruleset 469d4320 dropped.
+		These sniffs live in WordPress-Extra rather than WordPress-Core, so nothing
+		above brings them in and unescaped output on a new line passed lint.
+	-->
+	<rule ref="WordPress.Security"/>
+	<rule ref="WordPress.Security.EscapeOutput">
+		<properties>
+			<property name="customAutoEscapedFunctions" type="array">
+				<element value="zbsLink"/>
+				<element value="jpcrm_esc_link"/>
+			</property>
+		</properties>
+	</rule>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
@@ -51,5 +76,21 @@
 	<rule ref="Generic.CodeAnalysis.EmptyStatement"/>
 
 	<rule ref="PEAR.Functions.ValidDefaultValue.NotAtEnd"/>
+
+	<!--
+		Restored from .phpcs.dir.phpcompatibility.xml, the third ruleset 469d4320
+		dropped. The floor is the one the plugin advertises: `Requires PHP: 7.4` in
+		ZeroBSCRM.php and readme.txt, and `"php": ">=7.4"` in composer.json.
+
+		Know what this does not cover. php-compatibility's only released version is
+		9.3.5, from 2019, so its database stops at PHP 7.4. It catches the legacy
+		deprecations there are plenty of in here (`each()`, `create_function()`), and
+		it is blind to everything PHP 8.0 added. Write `str_contains()`, `match`, an
+		enum or `?->` and this will not say a word, though every one of them is a
+		fatal on the 7.4 we advertise. PHP 8 detection landed on the unreleased 10.x
+		branch. Until that ships, testing on 7.4 is the only thing that catches those.
+	-->
+	<config name="testVersion" value="7.4-"/>
+	<rule ref="PHPCompatibilityWP"/>
 
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -14,7 +14,11 @@
 		everything will bury you.
 	-->
 
-	<!-- Args to PHPCS: show (p)rogress, show (s)niff codes -->
+	<!--
+		Args to PHPCS: show (p)rogress, show (s)niff codes. Progress goes to stdout
+		ahead of the report, so anything asking for the JSON report needs -q with it
+		or the JSON will not parse. phpcs-changed passes -q itself.
+	-->
 	<arg value="ps"/>
 	<arg name="parallel" value="10"/>
 	<arg name="extensions" value="php"/>
@@ -25,30 +29,35 @@
 	<file>.</file>
 
 	<!--
-		Exclude patterns are matched, unanchored, against each file's absolute path.
-		`type="relative"` is supposed to match against the path from basepath
-		instead; it does nothing here, and a pattern written that way silently
-		excludes nothing, so do not reach for it.
+		Two kinds of exclude-pattern, and the difference matters.
 
-		The consequence is that a pattern cannot tell "this checkout's vendor/" from
-		"a checkout that happens to live under a vendor/". Fine for the directories
-		below, which we would never nest a checkout inside.
+		A plain pattern is matched, unanchored, against the file's absolute path. So
+		it cannot tell this checkout's `vendor/` from a checkout that happens to sit
+		under a `vendor/`. Fine for the five below, which we would never nest a
+		checkout inside, and it is the only form that works for a path handed to
+		phpcs on the command line, which is what phpcs-changed does.
+
+		`type="relative"` matches against the path relative to the scan root instead.
+		That only applies to a directory walk: for an explicit path the relative path
+		is empty and the pattern never fires. It is also discarded outright on a
+		rule-level exclude-pattern, where matching is always absolute.
+
+		`.claude/` needs the relative form and nothing else will do. It holds git
+		worktrees, which are whole second checkouts, so a walk from the repo root has
+		to skip them: without this the queue goes from 316 files to 1268 and phpcs
+		dies with "ran out of memory", while `phpcbf` quietly reformats another
+		branch's files. But an absolute pattern naming `.claude/` also matches every
+		file inside a worktree, because `.claude/` is in their paths too, and that is
+		how `make lint` came to report success there having examined nothing. The
+		relative form skips a nested `.claude/` without ever matching a worktree's
+		own source. Verified from both roots: 316 files either way.
 	-->
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/jetpack_vendor/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/build/*</exclude-pattern>
 	<exclude-pattern>*/dist/*</exclude-pattern>
-
-	<!--
-		There is deliberately no pattern for `.claude/`, which holds agent worktrees.
-		Those are whole second checkouts and a full-tree run should skip them, but a
-		worktree at `.claude/worktrees/x/` has `.claude/` in every path inside it, so
-		any pattern naming that directory excludes the worktree's own source too.
-		That is what happened: `make lint` in a worktree reported success having
-		linted nothing. A slow full-tree run is the better failure of the two, and
-		`git` never hands `.claude/` to phpcs-changed because it is untracked.
-	-->
+	<exclude-pattern type="relative">^\.claude/</exclude-pattern>
 
 	<rule ref="WordPress-Core">
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
@@ -64,8 +73,9 @@
 	<rule ref="WordPress.Security"/>
 	<rule ref="WordPress.Security.EscapeOutput">
 		<properties>
+			<!-- Lowercase only. The sniff lowercases the function it is checking but not this list, so a camelCase entry never matches. -->
 			<property name="customAutoEscapedFunctions" type="array">
-				<element value="zbsLink"/>
+				<element value="zbslink"/>
 				<element value="jpcrm_esc_link"/>
 			</property>
 		</properties>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -29,34 +29,40 @@
 	<file>.</file>
 
 	<!--
-		Two kinds of exclude-pattern, and the difference matters.
+		Every pattern here is `type="relative"`, and that is deliberate.
 
-		A plain pattern is matched, unanchored, against the file's absolute path. So
-		it cannot tell this checkout's `vendor/` from a checkout that happens to sit
-		under a `vendor/`. Fine for the five below, which we would never nest a
-		checkout inside, and it is the only form that works for a path handed to
-		phpcs on the command line, which is what phpcs-changed does.
+		A pattern is an unanchored regex, and a plain one is matched against the
+		file's absolute path. So it cannot tell this checkout's `build/` from a
+		checkout that sits under a directory called that: clone this to `~/build/` or
+		`~/dist/` and the tree excludes itself, leaving `make lint` to report success
+		having examined nothing. `type="relative"` matches against the path relative
+		to the scan root, which can never contain the checkout's own ancestors.
 
-		`type="relative"` matches against the path relative to the scan root instead.
-		That only applies to a directory walk: for an explicit path the relative path
-		is empty and the pattern never fires. It is also discarded outright on a
-		rule-level exclude-pattern, where matching is always absolute.
+		Nothing is given up by that. These top-level patterns only ever apply to a
+		directory walk, i.e. running `vendor/bin/phpcs` over the tree: they are read
+		by Filters/Filter.php, and phpcs-changed never reaches it, because it feeds
+		each file in on stdin, naming it with `stdin-path`. The rule-level excludes
+		further down are a different mechanism, matched in Files/File.php, and those
+		do apply to it. The one behaviour that changes is naming a vendored file
+		explicitly on the command line, which now lints it rather than ignoring you.
 
-		`.claude/` needs the relative form and nothing else will do. It holds git
-		worktrees, which are whole second checkouts, so a walk from the repo root has
-		to skip them: without this the queue goes from 316 files to 1268 and phpcs
-		dies with "ran out of memory", while `phpcbf` quietly reformats another
-		branch's files. But an absolute pattern naming `.claude/` also matches every
-		file inside a worktree, because `.claude/` is in their paths too, and that is
-		how `make lint` came to report success there having examined nothing. The
-		relative form skips a nested `.claude/` without ever matching a worktree's
-		own source. Verified from both roots: 316 files either way.
+		The `(^|/)` prefix is what the anchoring costs: without it `vendor/*` would
+		also match a `livevendor/` or `my_vendor/` anywhere in the tree.
+
+		`.claude/` has a second reason to be relative. It holds git worktrees, which
+		are whole second checkouts, so a walk from the repo root has to skip them:
+		without this the queue goes from 316 files to 1268 and phpcs dies with "ran
+		out of memory", while `phpcbf` quietly reformats another branch's files. But
+		an absolute pattern naming `.claude/` also matches every file inside a
+		worktree, because `.claude/` is in their paths too, and that is how `make
+		lint` came to report success there having examined nothing. Verified from
+		both roots: 316 files either way.
 	-->
-	<exclude-pattern>*/vendor/*</exclude-pattern>
-	<exclude-pattern>*/jetpack_vendor/*</exclude-pattern>
-	<exclude-pattern>*/node_modules/*</exclude-pattern>
-	<exclude-pattern>*/build/*</exclude-pattern>
-	<exclude-pattern>*/dist/*</exclude-pattern>
+	<exclude-pattern type="relative">(^|/)vendor/*</exclude-pattern>
+	<exclude-pattern type="relative">(^|/)jetpack_vendor/*</exclude-pattern>
+	<exclude-pattern type="relative">(^|/)node_modules/*</exclude-pattern>
+	<exclude-pattern type="relative">(^|/)build/*</exclude-pattern>
+	<exclude-pattern type="relative">(^|/)dist/*</exclude-pattern>
 	<exclude-pattern type="relative">^\.claude/</exclude-pattern>
 
 	<rule ref="WordPress-Core">

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -101,17 +101,16 @@
 		`tests/` only, rather than dropping the whole tree the way this ruleset used
 		to. Everything else, docblocks included, applies there as it does anywhere.
 
-		These carry the same `(^|/)` prefix as the top-level patterns, and here it is
-		load-bearing rather than tidiness. Files/File.php ignores the `type` attribute
-		outright and matches whatever path it was handed, and the two entry points
-		hand it different shapes: a directory walk gives an absolute path, while
-		phpcs-changed names each file with `stdin-path` and passes the output of `git
-		diff` through untouched, i.e. relative to the repo root. A leading `*/`
-		compiles to `.*/`, which needs a literal `/tests/` and so matches the walk but
-		never the day-to-day path. These five sniffs were firing on every test file
-		`make lint` looked at.
+		These carry the same `(^|/)` prefix as the top-level patterns, which here is
+		consistency rather than a fix. Files/File.php ignores the `type` attribute
+		outright and matches whatever path it was handed, but both entry points hand
+		it an absolute one: a walk by construction, and phpcs-changed because
+		Config.php realpaths the `stdin-path` argument (Config.php:1005) and keeps
+		the string it was given only when no such file exists. A leading `*/` matched
+		both, so the prefix widens these to a repo-relative path that in practice
+		never arrives.
 
-		This does not anchor to the repo root, and cannot: an absolute path has to
+		Neither shape anchors to the repo root, and cannot: an absolute path has to
 		match on the `/` branch, so a checkout under a directory called `tests` still
 		loses these five sniffs on a full-tree walk. Nothing here can tell that path
 		apart from a real one.

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<ruleset name="JPCRM Coding Standards">
+	<description>Verifies JPCRM code is up to snuff</description>
+
+	<!--
+		Restored from the ruleset this plugin used in the Jetpack monorepo, which was
+		dropped in 469d4320 (April 2023) and never replaced. Without a ruleset PHPCS
+		falls back to the PEAR standard, which is the opposite of WordPress style
+		(spaces for indentation, no Yoda conditions), so every lint run was noise.
+
+		The whole tree does not pass this. That is expected and is why the day-to-day
+		entry points (`make lint`, `make lint-staged`) go through phpcs-changed, which
+		reports only on the lines you touched. Running `vendor/bin/phpcs` directly over
+		everything will bury you.
+	-->
+
+	<!-- Args to PHPCS: show (p)rogress, show (s)niff codes -->
+	<arg value="ps"/>
+	<arg name="parallel" value="10"/>
+	<arg name="extensions" value="php"/>
+
+	<file>.</file>
+
+	<!-- Dependencies and build output. -->
+	<exclude-pattern>./vendor/*</exclude-pattern>
+	<exclude-pattern>./jetpack_vendor/*</exclude-pattern>
+	<exclude-pattern>./node_modules/*</exclude-pattern>
+	<exclude-pattern>./build/*</exclude-pattern>
+	<exclude-pattern>./dist/*</exclude-pattern>
+
+	<!-- Not source: agent worktrees are whole second checkouts of this repo. -->
+	<exclude-pattern>./.claude/*</exclude-pattern>
+
+	<exclude-pattern>./tests/*</exclude-pattern>
+
+	<rule ref="WordPress-Core">
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
+	</rule>
+
+	<rule ref="WordPress-Docs"/>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="zero-bs-crm"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- WPCS 3.0 dropped its own WordPress.CodeAnalysis.EmptyStatement wrapper. -->
+	<rule ref="Generic.CodeAnalysis.EmptyStatement"/>
+
+	<rule ref="PEAR.Functions.ValidDefaultValue.NotAtEnd"/>
+
+</ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -100,26 +100,41 @@
 		test suite and would fail correct test code. Each one below is turned off for
 		`tests/` only, rather than dropping the whole tree the way this ruleset used
 		to. Everything else, docblocks included, applies there as it does anywhere.
+
+		These carry the same `(^|/)` prefix as the top-level patterns, and here it is
+		load-bearing rather than tidiness. Files/File.php ignores the `type` attribute
+		outright and matches whatever path it was handed, and the two entry points
+		hand it different shapes: a directory walk gives an absolute path, while
+		phpcs-changed names each file with `stdin-path` and passes the output of `git
+		diff` through untouched, i.e. relative to the repo root. A leading `*/`
+		compiles to `.*/`, which needs a literal `/tests/` and so matches the walk but
+		never the day-to-day path. These five sniffs were firing on every test file
+		`make lint` looked at.
+
+		This does not anchor to the repo root, and cannot: an absolute path has to
+		match on the `/` branch, so a checkout under a directory called `tests` still
+		loses these five sniffs on a full-tree walk. Nothing here can tell that path
+		apart from a real one.
 	-->
 
 	<!-- PHPUnit finds classes by file name: List_View_Permissions_Test.php, not class-*.php. -->
 	<rule ref="WordPress.Files.FileName">
-		<exclude-pattern>*/tests/*</exclude-pattern>
+		<exclude-pattern>(^|/)tests/*</exclude-pattern>
 	</rule>
 
 	<!-- The test cases we extend expose properties we do not name: WP_Ajax_UnitTestCase::$_last_response, $zbs->DAL. -->
 	<rule ref="WordPress.NamingConventions.ValidVariableName">
-		<exclude-pattern>*/tests/*</exclude-pattern>
+		<exclude-pattern>(^|/)tests/*</exclude-pattern>
 	</rule>
 
 	<!-- Nothing in a test renders to a browser, and an assertion message is not output. -->
 	<rule ref="WordPress.Security.EscapeOutput">
-		<exclude-pattern>*/tests/*</exclude-pattern>
+		<exclude-pattern>(^|/)tests/*</exclude-pattern>
 	</rule>
 
 	<!-- Codeception's own API is camelCase and underscore-prefixed: tryToTest(), _before(). -->
 	<rule ref="WordPress.NamingConventions.ValidFunctionName">
-		<exclude-pattern>*/tests/codeception/*</exclude-pattern>
+		<exclude-pattern>(^|/)tests/codeception/*</exclude-pattern>
 	</rule>
 
 	<!--
@@ -128,7 +143,7 @@
 		the `#[TestDox]` attribute would be the same sentence written three times.
 	-->
 	<rule ref="Generic.Commenting.DocComment.MissingShort">
-		<exclude-pattern>*/tests/*</exclude-pattern>
+		<exclude-pattern>(^|/)tests/*</exclude-pattern>
 	</rule>
 
 	<!-- WPCS 3.0 dropped its own WordPress.CodeAnalysis.EmptyStatement wrapper. -->

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,38 @@ MAIN_ROOT := $(patsubst %/.git,%,$(abspath $(shell git rev-parse --git-common-di
 # where the container cannot reach it at all. Distinguishing that case from the
 # main checkout matters: conflating them runs the main checkout's tests and
 # reports them as the worktree's.
-WORKTREE_REL := $(if $(filter $(MAIN_ROOT),$(WORKTREE_ROOT)),,$(patsubst $(MAIN_ROOT)/%,%,$(WORKTREE_ROOT)))
+#
+# Done in awk rather than with make's $(filter) and $(patsubst), both of which
+# split their arguments on whitespace. A checkout path with a space in it
+# matched on its first word alone, and a worktree under it came out looking like
+# the main checkout, which is the conflation above. Keep the parens balanced:
+# make counts them inside $(shell ...) whatever the quoting, so a `case` arm
+# closes the call early.
+WORKTREE_REL := $(shell awk -v m="$(MAIN_ROOT)" -v r="$(WORKTREE_ROOT)" 'BEGIN { if (r == m) print ""; else if (substr(r, 1, length(m) + 1) == m "/") print substr(r, length(m) + 2); else print r }')
 
 # This checkout's path inside the container.
 ENV_CWD := wp-content/plugins/$(notdir $(MAIN_ROOT))$(if $(WORKTREE_REL),/$(WORKTREE_REL))
+
+# The same guard on every target that needs vendor/, in one copy so the three
+# cannot drift apart. Takes the binary to look for, and works out which of the
+# three ways it can be missing you are actually in, since "run make install" is
+# no help when vendor/ is a symlink pointing at a main checkout that has none.
+define require_vendor
+@if [ ! -e "$(1)" ]; then \
+	if [ -L vendor ] && [ ! -e vendor ]; then \
+		echo "Error: vendor/ here is a symlink into $(MAIN_ROOT), which has no vendor/ of its own." >&2; \
+		echo "Run 'make install' in $(MAIN_ROOT)." >&2; \
+	elif [ ! -e vendor ] && [ -n "$(WORKTREE_REL)" ]; then \
+		echo "Error: vendor/ is missing in $(WORKTREE_ROOT)." >&2; \
+		echo "Run 'make worktree-link' to link it from $(MAIN_ROOT)." >&2; \
+	elif [ -n "$(WORKTREE_REL)" ]; then \
+		echo "Error: $(1) is missing. Run 'make install' in $(MAIN_ROOT), which is where vendor/ points." >&2; \
+	else \
+		echo "Error: $(1) is missing. Run 'make install'." >&2; \
+	fi; \
+	exit 1; \
+fi
+endef
 
 # Use the locally-installed @wordpress/env (a devDependency) rather than fetching
 # it via `npx --yes` on every call, which needs registry access on each run.
@@ -46,7 +74,11 @@ install-hooks: ## Install git hooks (fail-fast guard against direct pushes to tr
 
 # One shell for the whole recipe: each make recipe line gets its own shell, so an
 # `exit 0` on the first line would not stop the later ones from linking anyway.
-worktree-link: ## Symlink vendor/ and jetpack_vendor/ into this worktree from the main checkout
+#
+# node_modules is linked too, for `make lint-css`. Note what that means: npm and
+# composer run in a worktree write into the main checkout's directories, the
+# same as they already did for vendor/. Install in the main checkout.
+worktree-link: ## Symlink vendor/, jetpack_vendor/ and node_modules/ into this worktree
 	@case "$(WORKTREE_REL)" in \
 		"") \
 			echo "Not a worktree, nothing to link.";; \
@@ -57,7 +89,7 @@ worktree-link: ## Symlink vendor/ and jetpack_vendor/ into this worktree from th
 			exit 1;; \
 		*) \
 			up=$$(echo "$(WORKTREE_REL)" | sed 's#[^/][^/]*#..#g'); \
-			for d in vendor jetpack_vendor; do \
+			for d in vendor jetpack_vendor node_modules; do \
 				if [ -e "$$d" ] && [ ! -L "$$d" ]; then \
 					echo "Skipping $$d, it is a real directory."; \
 					continue; \
@@ -97,32 +129,35 @@ test: $(WP_ENV_BIN) ## Run the PHPUnit unit suite. Usage: make test [ARGS="--fil
 		echo "Error: this worktree is outside $(MAIN_ROOT), so the container cannot see it." >&2; \
 		echo "Create worktrees under .claude/worktrees/ to run tests in them." >&2; \
 		exit 1;; esac
-	@test -e vendor/bin/phpunit || { \
-		echo "Error: vendor/ is missing in $(WORKTREE_ROOT)." >&2; \
-		echo "Run 'make worktree-link' in a worktree, or 'make install' in a fresh clone." >&2; \
+	$(call require_vendor,vendor/bin/phpunit)
+	@# A liveness probe, so a stopped environment says so rather than surfacing a
+	@# raw docker compose error. It has to be its own call: folding it into the
+	@# run below would report a failing test suite as a stopped container.
+	@cd "$(MAIN_ROOT)" && $(WP_ENV) run tests-cli true >/dev/null 2>&1 || { \
+		echo "Error: the wp-env containers are not running. Run 'make up' first." >&2; \
 		exit 1; }
 	@# wp-env keys its state directory on the directory it is invoked from, so it
 	@# has to run from the main checkout. --env-cwd then points it at this one.
-	cd $(MAIN_ROOT) && $(WP_ENV) run tests-cli --env-cwd=$(ENV_CWD) \
-		bash -c 'WORDPRESS_DEVELOP_DIR=/wordpress-phpunit composer phpunit -- $(ARGS)'
+	@# ARGS goes in as positional parameters rather than into the single-quoted
+	@# script, so ARGS="--filter 'It works'" keeps its quoting.
+	cd "$(MAIN_ROOT)" && $(WP_ENV) run tests-cli --env-cwd="$(ENV_CWD)" \
+		bash -c 'WORDPRESS_DEVELOP_DIR=/wordpress-phpunit composer phpunit -- "$$@"' -- $(ARGS)
 
 test-acceptance: ## Run the Codeception acceptance suite (needs a configured WP + browser)
 	composer tests
 
 ## Lint
 lint: ## Run PHP CodeSniffer on changed files (vs trunk)
-	@test -e vendor/bin/phpcs-changed || { \
-		echo "Error: vendor/ is missing in $(WORKTREE_ROOT)." >&2; \
-		echo "Run 'make worktree-link' in a worktree, or 'make install' in a fresh clone." >&2; \
-		exit 1; }
+	$(call require_vendor,vendor/bin/phpcs-changed)
 	composer cs
 
 lint-staged: ## Run PHP CodeSniffer on staged files
-	@test -e vendor/bin/phpcs-changed || { \
-		echo "Error: vendor/ is missing in $(WORKTREE_ROOT)." >&2; \
-		echo "Run 'make worktree-link' in a worktree, or 'make install' in a fresh clone." >&2; \
-		exit 1; }
+	$(call require_vendor,vendor/bin/phpcs-changed)
 	composer cs-staged
+
+lint-unstaged: ## Run PHP CodeSniffer on unstaged working tree changes
+	$(call require_vendor,vendor/bin/phpcs-changed)
+	composer cs-unstaged
 
 lint-css: ## Check WPDS design token usage in the Sass sources
 	npm run lint:css
@@ -145,4 +180,4 @@ i18n: ## Regenerate translation files (no-op: JPCRM translations come from trans
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-16s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: install install-hooks worktree-link up down destroy logs cli wp test test-acceptance lint lint-staged lint-css release build clean i18n help
+.PHONY: install install-hooks worktree-link up down destroy logs cli wp test test-acceptance lint lint-staged lint-unstaged lint-css release build clean i18n help

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,14 @@ wp: $(WP_ENV_BIN) ## Run an arbitrary wp-cli command, e.g. `make wp CMD="plugin 
 	$(WP_ENV) run cli wp $(CMD)
 
 ## Test
-test: ## Run the PHPUnit unit suite
-	composer phpunit
+# The suite needs the WordPress test library, which only exists inside the
+# wp-env tests container (at /wordpress-phpunit). Running it on the host fails
+# with "Failed to automatically locate WordPress or wordpress-develop".
+# WORDPRESS_DEVELOP_DIR has to be set explicitly: the container's own WP_TESTS_DIR
+# is not the variable tests/php/bootstrap.php looks at.
+test: $(WP_ENV_BIN) ## Run the PHPUnit unit suite. Usage: make test [ARGS="--filter Foo"]
+	$(WP_ENV) run tests-cli --env-cwd=wp-content/plugins/$(notdir $(CURDIR)) \
+		bash -c 'WORDPRESS_DEVELOP_DIR=/wordpress-phpunit composer phpunit -- $(ARGS)'
 
 test-acceptance: ## Run the Codeception acceptance suite (needs a configured WP + browser)
 	composer tests

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,11 @@ MAIN_ROOT := $(patsubst %/.git,%,$(abspath $(shell git rev-parse --git-common-di
 # main checkout matters: conflating them runs the main checkout's tests and
 # reports them as the worktree's.
 #
-# Done in awk rather than with make's $(filter) and $(patsubst), both of which
-# split their arguments on whitespace. A checkout path with a space in it
-# matched on its first word alone, and a worktree under it came out looking like
-# the main checkout, which is the conflation above. Keep the parens balanced:
-# make counts them inside $(shell ...) whatever the quoting, so a `case` arm
-# closes the call early.
-WORKTREE_REL := $(shell awk -v m="$(MAIN_ROOT)" -v r="$(WORKTREE_ROOT)" 'BEGIN { if (r == m) print ""; else if (substr(r, 1, length(m) + 1) == m "/") print substr(r, length(m) + 2); else print r }')
+# A checkout path containing a space is not supported here. $(filter) and
+# $(patsubst) below split on whitespace, as do $(abspath) and $(notdir) above
+# and either side, so such a path matches on its first word alone and a worktree
+# under it comes out looking like the main checkout.
+WORKTREE_REL := $(if $(filter $(MAIN_ROOT),$(WORKTREE_ROOT)),,$(patsubst $(MAIN_ROOT)/%,%,$(WORKTREE_ROOT)))
 
 # This checkout's path inside the container.
 ENV_CWD := wp-content/plugins/$(notdir $(MAIN_ROOT))$(if $(WORKTREE_REL),/$(WORKTREE_REL))
@@ -94,7 +92,7 @@ worktree-link: ## Symlink vendor/, jetpack_vendor/ and node_modules/ into this w
 					echo "Skipping $$d, it is a real directory."; \
 					continue; \
 				fi; \
-				ln -sfn "$$up/$$d" "$$d"; \
+				ln -sfn "$$up/$$d" "$$d" || exit 1; \
 				echo "Linked $$d -> $$up/$$d"; \
 			done; \
 			echo "Relative links, so they resolve inside the container too.";; \

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,9 @@ test: $(WP_ENV_BIN) ## Run the PHPUnit unit suite. Usage: make test [ARGS="--fil
 	@# sees it, and `make test ARGS="--testsuite pdf"` arrives as just `pdf`.
 	@# Interpolating ARGS raw does not work either, since the recipe shell has
 	@# already stripped the quotes by then and ARGS="--filter 'It works'" splits.
-	cd "$(MAIN_ROOT)" && args=$$(printf '%q ' $(ARGS)) && \
+	@# %q is run per word: `printf '%q '` with no operands still runs the format
+	@# once and yields '', so an unset ARGS would send phpunit an empty argument.
+	cd "$(MAIN_ROOT)" && args=$$(for a in $(ARGS); do printf '%q ' "$$a"; done) && \
 		$(WP_ENV) run tests-cli --env-cwd="$(ENV_CWD)" \
 		bash -c "WORDPRESS_DEVELOP_DIR=/wordpress-phpunit composer phpunit -- $$args"
 

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,30 @@
 SHELL := /bin/bash
 
 PLUGIN_NAME := zero-bs-crm
+
+# Where this checkout is, and where the main one is. They differ when make is run
+# from a git worktree. wp-env only ever mounts the main checkout, but a worktree
+# under .claude/worktrees/ sits inside that mount, so the container can see its
+# files. What it can't see is vendor/ and jetpack_vendor/, which are gitignored
+# and so absent from a fresh worktree: `make worktree-link` puts them there.
+WORKTREE_ROOT := $(shell git rev-parse --show-toplevel 2>/dev/null)
+MAIN_ROOT := $(patsubst %/.git,%,$(abspath $(shell git rev-parse --git-common-dir 2>/dev/null)))
+
+# Empty in the main checkout; the worktree's path below it otherwise. Stays
+# absolute (leading slash) when the worktree lives outside the main checkout,
+# where the container cannot reach it at all. Distinguishing that case from the
+# main checkout matters: conflating them runs the main checkout's tests and
+# reports them as the worktree's.
+WORKTREE_REL := $(if $(filter $(MAIN_ROOT),$(WORKTREE_ROOT)),,$(patsubst $(MAIN_ROOT)/%,%,$(WORKTREE_ROOT)))
+
+# This checkout's path inside the container.
+ENV_CWD := wp-content/plugins/$(notdir $(MAIN_ROOT))$(if $(WORKTREE_REL),/$(WORKTREE_REL))
+
 # Use the locally-installed @wordpress/env (a devDependency) rather than fetching
 # it via `npx --yes` on every call, which needs registry access on each run.
-# Run `make install` (npm install) once to populate it.
-WP_ENV_BIN := node_modules/.bin/wp-env
+# Run `make install` (npm install) once to populate it. Always the main
+# checkout's copy: worktrees have no node_modules.
+WP_ENV_BIN := $(MAIN_ROOT)/node_modules/.bin/wp-env
 WP_ENV := COMPOSE_PROJECT_NAME=$(PLUGIN_NAME) $(WP_ENV_BIN)
 
 # Guard: any wp-env target depends on this. If the binary is missing the recipe
@@ -23,6 +43,30 @@ install: ## Install PHP (Composer) and JS (npm) dependencies
 install-hooks: ## Install git hooks (fail-fast guard against direct pushes to trunk)
 	git config core.hooksPath .githooks
 	@echo "Git hooks installed (core.hooksPath = .githooks)."
+
+# One shell for the whole recipe: each make recipe line gets its own shell, so an
+# `exit 0` on the first line would not stop the later ones from linking anyway.
+worktree-link: ## Symlink vendor/ and jetpack_vendor/ into this worktree from the main checkout
+	@case "$(WORKTREE_REL)" in \
+		"") \
+			echo "Not a worktree, nothing to link.";; \
+		/*) \
+			echo "Error: this worktree is outside $(MAIN_ROOT)." >&2; \
+			echo "wp-env only mounts the main checkout, so the container cannot see it." >&2; \
+			echo "Create worktrees under .claude/worktrees/ to run tests in them." >&2; \
+			exit 1;; \
+		*) \
+			up=$$(echo "$(WORKTREE_REL)" | sed 's#[^/][^/]*#..#g'); \
+			for d in vendor jetpack_vendor; do \
+				if [ -e "$$d" ] && [ ! -L "$$d" ]; then \
+					echo "Skipping $$d, it is a real directory."; \
+					continue; \
+				fi; \
+				ln -sfn "$$up/$$d" "$$d"; \
+				echo "Linked $$d -> $$up/$$d"; \
+			done; \
+			echo "Relative links, so they resolve inside the container too.";; \
+	esac
 
 up: $(WP_ENV_BIN) ## Start WordPress in Docker (http://localhost:8888, admin/password)
 	$(WP_ENV) start
@@ -49,7 +93,17 @@ wp: $(WP_ENV_BIN) ## Run an arbitrary wp-cli command, e.g. `make wp CMD="plugin 
 # WORDPRESS_DEVELOP_DIR has to be set explicitly: the container's own WP_TESTS_DIR
 # is not the variable tests/php/bootstrap.php looks at.
 test: $(WP_ENV_BIN) ## Run the PHPUnit unit suite. Usage: make test [ARGS="--filter Foo"]
-	$(WP_ENV) run tests-cli --env-cwd=wp-content/plugins/$(notdir $(CURDIR)) \
+	@case "$(WORKTREE_REL)" in /*) \
+		echo "Error: this worktree is outside $(MAIN_ROOT), so the container cannot see it." >&2; \
+		echo "Create worktrees under .claude/worktrees/ to run tests in them." >&2; \
+		exit 1;; esac
+	@test -e vendor/bin/phpunit || { \
+		echo "Error: vendor/ is missing in $(WORKTREE_ROOT)." >&2; \
+		echo "Run 'make worktree-link' in a worktree, or 'make install' in a fresh clone." >&2; \
+		exit 1; }
+	@# wp-env keys its state directory on the directory it is invoked from, so it
+	@# has to run from the main checkout. --env-cwd then points it at this one.
+	cd $(MAIN_ROOT) && $(WP_ENV) run tests-cli --env-cwd=$(ENV_CWD) \
 		bash -c 'WORDPRESS_DEVELOP_DIR=/wordpress-phpunit composer phpunit -- $(ARGS)'
 
 test-acceptance: ## Run the Codeception acceptance suite (needs a configured WP + browser)
@@ -57,9 +111,17 @@ test-acceptance: ## Run the Codeception acceptance suite (needs a configured WP 
 
 ## Lint
 lint: ## Run PHP CodeSniffer on changed files (vs trunk)
+	@test -e vendor/bin/phpcs-changed || { \
+		echo "Error: vendor/ is missing in $(WORKTREE_ROOT)." >&2; \
+		echo "Run 'make worktree-link' in a worktree, or 'make install' in a fresh clone." >&2; \
+		exit 1; }
 	composer cs
 
 lint-staged: ## Run PHP CodeSniffer on staged files
+	@test -e vendor/bin/phpcs-changed || { \
+		echo "Error: vendor/ is missing in $(WORKTREE_ROOT)." >&2; \
+		echo "Run 'make worktree-link' in a worktree, or 'make install' in a fresh clone." >&2; \
+		exit 1; }
 	composer cs-staged
 
 lint-css: ## Check WPDS design token usage in the Sass sources
@@ -83,4 +145,4 @@ i18n: ## Regenerate translation files (no-op: JPCRM translations come from trans
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-16s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: install install-hooks up down destroy logs cli wp test test-acceptance lint lint-staged lint-css release build clean i18n help
+.PHONY: install install-hooks worktree-link up down destroy logs cli wp test test-acceptance lint lint-staged lint-css release build clean i18n help

--- a/Makefile
+++ b/Makefile
@@ -138,10 +138,16 @@ test: $(WP_ENV_BIN) ## Run the PHPUnit unit suite. Usage: make test [ARGS="--fil
 		exit 1; }
 	@# wp-env keys its state directory on the directory it is invoked from, so it
 	@# has to run from the main checkout. --env-cwd then points it at this one.
-	@# ARGS goes in as positional parameters rather than into the single-quoted
-	@# script, so ARGS="--filter 'It works'" keeps its quoting.
-	cd "$(MAIN_ROOT)" && $(WP_ENV) run tests-cli --env-cwd="$(ENV_CWD)" \
-		bash -c 'WORDPRESS_DEVELOP_DIR=/wordpress-phpunit composer phpunit -- "$$@"' -- $(ARGS)
+	@#
+	@# ARGS is re-quoted with %q and folded into the one string wp-env is given.
+	@# It cannot be passed as separate arguments after it: wp-env parses its own
+	@# argv, so anything looking like an option is eaten before the container
+	@# sees it, and `make test ARGS="--testsuite pdf"` arrives as just `pdf`.
+	@# Interpolating ARGS raw does not work either, since the recipe shell has
+	@# already stripped the quotes by then and ARGS="--filter 'It works'" splits.
+	cd "$(MAIN_ROOT)" && args=$$(printf '%q ' $(ARGS)) && \
+		$(WP_ENV) run tests-cli --env-cwd="$(ENV_CWD)" \
+		bash -c "WORDPRESS_DEVELOP_DIR=/wordpress-phpunit composer phpunit -- $$args"
 
 test-acceptance: ## Run the Codeception acceptance suite (needs a configured WP + browser)
 	composer tests

--- a/Makefile
+++ b/Makefile
@@ -11,40 +11,39 @@ PLUGIN_NAME := zero-bs-crm
 WORKTREE_ROOT := $(shell git rev-parse --show-toplevel 2>/dev/null)
 MAIN_ROOT := $(patsubst %/.git,%,$(abspath $(shell git rev-parse --git-common-dir 2>/dev/null)))
 
-# Empty in the main checkout; the worktree's path below it otherwise. Stays
-# absolute (leading slash) when the worktree lives outside the main checkout,
-# where the container cannot reach it at all. Distinguishing that case from the
-# main checkout matters: conflating them runs the main checkout's tests and
-# reports them as the worktree's.
+# Empty in the main checkout; the worktree's path below it otherwise; and left
+# absolute, leading slash and all, when the worktree is not below it at all.
+# require_inside below is what acts on that third case.
 #
 # A checkout path containing a space is not supported here. $(filter) and
-# $(patsubst) below split on whitespace, as do $(abspath) and $(notdir) above
-# and either side, so such a path matches on its first word alone and a worktree
-# under it comes out looking like the main checkout.
+# $(patsubst) below split on whitespace, as do $(abspath) and $(notdir) either
+# side, so such a path matches on its first word alone and a worktree under it
+# comes out looking like the main checkout.
 WORKTREE_REL := $(if $(filter $(MAIN_ROOT),$(WORKTREE_ROOT)),,$(patsubst $(MAIN_ROOT)/%,%,$(WORKTREE_ROOT)))
 
 # This checkout's path inside the container.
 ENV_CWD := wp-content/plugins/$(notdir $(MAIN_ROOT))$(if $(WORKTREE_REL),/$(WORKTREE_REL))
 
 # The same guard on every target that needs vendor/, in one copy so the three
-# cannot drift apart. Takes the binary to look for, and works out which of the
-# three ways it can be missing you are actually in, since "run make install" is
-# no help when vendor/ is a symlink pointing at a main checkout that has none.
+# cannot drift apart. Composer installs into the main checkout whichever tree
+# you run it from, so that is where the advice points in every case.
 define require_vendor
 @if [ ! -e "$(1)" ]; then \
-	if [ -L vendor ] && [ ! -e vendor ]; then \
-		echo "Error: vendor/ here is a symlink into $(MAIN_ROOT), which has no vendor/ of its own." >&2; \
-		echo "Run 'make install' in $(MAIN_ROOT)." >&2; \
-	elif [ ! -e vendor ] && [ -n "$(WORKTREE_REL)" ]; then \
-		echo "Error: vendor/ is missing in $(WORKTREE_ROOT)." >&2; \
-		echo "Run 'make worktree-link' to link it from $(MAIN_ROOT)." >&2; \
-	elif [ -n "$(WORKTREE_REL)" ]; then \
-		echo "Error: $(1) is missing. Run 'make install' in $(MAIN_ROOT), which is where vendor/ points." >&2; \
-	else \
-		echo "Error: $(1) is missing. Run 'make install'." >&2; \
-	fi; \
+	echo "Error: $(1) is missing. Run 'make install' in $(MAIN_ROOT)." >&2; \
+	echo "In a worktree, 'make worktree-link' as well." >&2; \
 	exit 1; \
 fi
+endef
+
+# wp-env only mounts the main checkout. A worktree under it is visible to the
+# container; one anywhere else is not, and neither target can do anything useful
+# there. Refuse rather than fall back to the main checkout and report its results
+# as the worktree's.
+define require_inside
+@case "$(WORKTREE_REL)" in /*) \
+	echo "Error: $(WORKTREE_ROOT) is outside $(MAIN_ROOT), which is all wp-env mounts." >&2; \
+	echo "Create worktrees under .claude/worktrees/ to use them here." >&2; \
+	exit 1;; esac
 endef
 
 # Use the locally-installed @wordpress/env (a devDependency) rather than fetching
@@ -77,14 +76,10 @@ install-hooks: ## Install git hooks (fail-fast guard against direct pushes to tr
 # composer run in a worktree write into the main checkout's directories, the
 # same as they already did for vendor/. Install in the main checkout.
 worktree-link: ## Symlink vendor/, jetpack_vendor/ and node_modules/ into this worktree
+	$(call require_inside)
 	@case "$(WORKTREE_REL)" in \
 		"") \
 			echo "Not a worktree, nothing to link.";; \
-		/*) \
-			echo "Error: this worktree is outside $(MAIN_ROOT)." >&2; \
-			echo "wp-env only mounts the main checkout, so the container cannot see it." >&2; \
-			echo "Create worktrees under .claude/worktrees/ to run tests in them." >&2; \
-			exit 1;; \
 		*) \
 			up=$$(echo "$(WORKTREE_REL)" | sed 's#[^/][^/]*#..#g'); \
 			for d in vendor jetpack_vendor node_modules; do \
@@ -123,10 +118,7 @@ wp: $(WP_ENV_BIN) ## Run an arbitrary wp-cli command, e.g. `make wp CMD="plugin 
 # WORDPRESS_DEVELOP_DIR has to be set explicitly: the container's own WP_TESTS_DIR
 # is not the variable tests/php/bootstrap.php looks at.
 test: $(WP_ENV_BIN) ## Run the PHPUnit unit suite. Usage: make test [ARGS="--filter Foo"]
-	@case "$(WORKTREE_REL)" in /*) \
-		echo "Error: this worktree is outside $(MAIN_ROOT), so the container cannot see it." >&2; \
-		echo "Create worktrees under .claude/worktrees/ to run tests in them." >&2; \
-		exit 1;; esac
+	$(call require_inside)
 	$(call require_vendor,vendor/bin/phpunit)
 	@# A liveness probe, so a stopped environment says so rather than surfacing a
 	@# raw docker compose error. It has to be its own call: folding it into the

--- a/README.md
+++ b/README.md
@@ -48,10 +48,47 @@ The plugin is mounted into the container, so edits are picked up live (run
 | `make logs` | Tail the WordPress container logs |
 | `make cli` | Open a shell inside the `cli` container |
 | `make wp CMD="plugin list"` | Run a wp-cli command in the container |
-| `make test` | Run the PHPUnit unit suite |
-| `make lint` | Run PHP CodeSniffer on files changed vs `trunk` |
+| `make test` | Run the PHPUnit unit suite (needs `make up` first) |
+| `make lint` | Run PHP CodeSniffer on files committed on this branch vs `trunk` |
+| `make lint-staged` | Run PHP CodeSniffer on staged changes |
+| `make lint-unstaged` | Run PHP CodeSniffer on unstaged working tree changes |
 | `make build` | Build `dist/zero-bs-crm.zip` (tracked source from `HEAD`, assets compiled fresh) |
 | `make clean` | Remove the `dist/` staging directory |
+
+### Tests
+
+`make test` runs inside the wp-env `tests-cli` container, so bring the
+environment up first with `make up`. It takes phpunit flags via `ARGS`:
+
+```sh
+make test                             # the whole unit suite
+make test ARGS="--testsuite pdf"      # one suite
+make test ARGS="--filter Company"     # one test or class
+```
+
+### Linting
+
+Every lint target reports only on the lines you touched, not on the whole file,
+because the tree as a whole does not pass the ruleset in `.phpcs.xml.dist`. A
+run that finds nothing says `No PHP changes found.`; a run that finds something
+exits non-zero.
+
+`make lint` covers what you have committed on this branch. Uncommitted work is
+`make lint-staged` and `make lint-unstaged`. Neither phpcs nor phpunit runs in
+CI yet, so these are local-only.
+
+### Working in a git worktree
+
+Both `make test` and `make lint` work from a worktree under `.claude/worktrees/`,
+which is inside the directory wp-env mounts. `vendor/`, `jetpack_vendor/` and
+`node_modules/` are gitignored and so absent there — run `make worktree-link`
+once to symlink them in from the main checkout. Note what that shares: npm and
+composer run in a worktree write into the main checkout.
+
+wp-env itself only runs from the main checkout, since it keys its state
+directory on the invocation directory. A worktree placed anywhere other than
+inside the main checkout can't work at all, and the targets say so rather than
+falling back. Neither is a checkout path containing a space supported.
 
 ## Publishing a release
 

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,17 @@
 		"squizlabs/php_codesniffer": "^3.13",
 		"wp-coding-standards/wpcs": "^3.2",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.1",
-		"sirbrillig/phpcs-changed": "^2.11"
+		"sirbrillig/phpcs-changed": "^2.11",
+		"phpcompatibility/phpcompatibility-wp": "^2.1"
 	},
 	"scripts": {
 		"tests": "php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/codecept run acceptance --fail-fast",
 		"tests-debug": "php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/codecept run acceptance --fail-fast --debug",
 		"create-test": "php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/codecept generate:cest acceptance $1",
 		"build-tests": "php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/codecept build",
-		"cs": "files=$(git diff --diff-filter=d --name-only trunk HEAD -- '*.php'); if [ -z \"$files\" ]; then echo 'No PHP changes found.'; else php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpcs-changed -s --git --git-base trunk --phpcs-path scripts/phpcs.sh $files; fi",
-		"cs-staged": "files=$(git diff --diff-filter=d --name-only --cached -- '*.php'); if [ -z \"$files\" ]; then echo 'No PHP changes found.'; else php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpcs-changed -s --git --git-staged --phpcs-path scripts/phpcs.sh $files; fi",
-		"cs-unstaged": "files=$(git diff --diff-filter=d --name-only -- '*.php'); if [ -z \"$files\" ]; then echo 'No PHP changes found.'; else php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpcs-changed -s --git --git-unstaged --phpcs-path scripts/phpcs.sh $files; fi",
+		"cs": "if ! files=$(git diff --diff-filter=d --name-only trunk HEAD -- '*.php'); then echo 'Could not diff against trunk.' >&2; exit 1; fi; if [ -z \"$files\" ]; then echo 'No PHP changes found.'; else php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpcs-changed -s --git --git-base trunk --phpcs-path scripts/phpcs.sh $files; fi",
+		"cs-staged": "if ! files=$(git diff --diff-filter=d --name-only --cached -- '*.php'); then echo 'Could not read staged changes.' >&2; exit 1; fi; if [ -z \"$files\" ]; then echo 'No PHP changes found.'; else php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpcs-changed -s --git --git-staged --phpcs-path scripts/phpcs.sh $files; fi",
+		"cs-unstaged": "if ! files=$(git diff --diff-filter=d --name-only -- '*.php'); then echo 'Could not read unstaged changes.' >&2; exit 1; fi; if [ -z \"$files\" ]; then echo 'No PHP changes found.'; else php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpcs-changed -s --git --git-unstaged --phpcs-path scripts/phpcs.sh $files; fi",
 		"phpunit": [
 			"phpunit=\"php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpunit\"; config=\"phpunit.$($phpunit --version | sed -n 's/^PHPUnit \\([0-9][0-9]*\\).*/\\1/p').xml.dist\"; $phpunit -c \"$config\" --colors=always"
 		]

--- a/composer.json
+++ b/composer.json
@@ -10,18 +10,22 @@
 		"codeception/module-filesystem": "^2.0 || ^3.0",
 		"codeception/util-universalframework": "^1.0 || ^2.0",
 		"yoast/phpunit-polyfills": "^4.0.0",
-		"automattic/phpunit-select-config": "^1.0.6"
+		"automattic/phpunit-select-config": "^1.0.6",
+		"squizlabs/php_codesniffer": "^3.13",
+		"wp-coding-standards/wpcs": "^3.2",
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.1",
+		"sirbrillig/phpcs-changed": "^2.11"
 	},
 	"scripts": {
 		"tests": "php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/codecept run acceptance --fail-fast",
 		"tests-debug": "php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/codecept run acceptance --fail-fast --debug",
 		"create-test": "php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/codecept generate:cest acceptance $1",
 		"build-tests": "php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/codecept build",
-		"cs": "temp=$(git diff --diff-filter=d --name-only trunk HEAD | grep '.php'); [[ -n $temp ]] && phpcs-changed -s --always-exit-zero --git --git-base trunk $temp || echo 'No changes found.'",
-		"cs-staged": "temp=$(git diff --diff-filter=d --name-only --cached | grep '.php'); [[ -n $temp ]] && phpcs-changed -s --always-exit-zero --git --git-staged $temp || echo 'No changes found.'",
-		"cs-unstaged": "temp=$(git diff --diff-filter=d --name-only | grep '.php'); [[ -n $temp ]] && phpcs-changed -s --always-exit-zero --git --git-unstaged $temp || echo 'No changes found.'",
+		"cs": "files=$(git diff --diff-filter=d --name-only trunk HEAD -- '*.php'); if [ -z \"$files\" ]; then echo 'No PHP changes found.'; else php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpcs-changed -s --git --git-base trunk --phpcs-path scripts/phpcs.sh $files; fi",
+		"cs-staged": "files=$(git diff --diff-filter=d --name-only --cached -- '*.php'); if [ -z \"$files\" ]; then echo 'No PHP changes found.'; else php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpcs-changed -s --git --git-staged --phpcs-path scripts/phpcs.sh $files; fi",
+		"cs-unstaged": "files=$(git diff --diff-filter=d --name-only -- '*.php'); if [ -z \"$files\" ]; then echo 'No PHP changes found.'; else php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpcs-changed -s --git --git-unstaged --phpcs-path scripts/phpcs.sh $files; fi",
 		"phpunit": [
-			"php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpunit-select-config phpunit.#.xml.dist --colors=always"
+			"phpunit=\"php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpunit\"; config=\"phpunit.$($phpunit --version | sed -n 's/^PHPUnit \\([0-9][0-9]*\\).*/\\1/p').xml.dist\"; $phpunit -c \"$config\" --colors=always"
 		]
 	},
 	"config": {
@@ -29,6 +33,7 @@
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true,
 			"roots/wordpress-core-installer": true
 		}
 	},

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
 		"tests-debug": "php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/codecept run acceptance --fail-fast --debug",
 		"create-test": "php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/codecept generate:cest acceptance $1",
 		"build-tests": "php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/codecept build",
-		"cs": "if ! files=$(git diff --diff-filter=d --name-only trunk HEAD -- '*.php'); then echo 'Could not diff against trunk.' >&2; exit 1; fi; if [ -z \"$files\" ]; then echo 'No PHP changes found.'; else php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpcs-changed -s --git --git-base trunk --phpcs-path scripts/phpcs.sh $files; fi",
-		"cs-staged": "if ! files=$(git diff --diff-filter=d --name-only --cached -- '*.php'); then echo 'Could not read staged changes.' >&2; exit 1; fi; if [ -z \"$files\" ]; then echo 'No PHP changes found.'; else php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpcs-changed -s --git --git-staged --phpcs-path scripts/phpcs.sh $files; fi",
-		"cs-unstaged": "if ! files=$(git diff --diff-filter=d --name-only -- '*.php'); then echo 'Could not read unstaged changes.' >&2; exit 1; fi; if [ -z \"$files\" ]; then echo 'No PHP changes found.'; else php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpcs-changed -s --git --git-unstaged --phpcs-path scripts/phpcs.sh $files; fi",
+		"cs": "scripts/phpcs-changed.sh base",
+		"cs-staged": "scripts/phpcs-changed.sh staged",
+		"cs-unstaged": "scripts/phpcs-changed.sh unstaged",
 		"phpunit": [
-			"phpunit=\"php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpunit\"; config=\"phpunit.$($phpunit --version | sed -n 's/^PHPUnit \\([0-9][0-9]*\\).*/\\1/p').xml.dist\"; $phpunit -c \"$config\" --colors=always"
+			"phpunit=\"php -d auto_prepend_file=tests/suppress_php84_deprecations.php vendor/bin/phpunit\"; major=$($phpunit --version | sed -n 's/^PHPUnit \\([0-9][0-9]*\\).*/\\1/p'); if [ -z \"$major\" ]; then echo 'Could not read a major version out of phpunit --version, so cannot pick a config.' >&2; exit 1; fi; $phpunit -c \"phpunit.$major.xml.dist\" --colors=always"
 		]
 	},
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0df3359a93808674773b89007682f72",
+    "content-hash": "b249b68f172db974dd0fc89bddec0d2a",
     "packages": [
         {
             "name": "automattic/jetpack-assets",
@@ -1597,6 +1597,102 @@
             "time": "2025-12-15T11:29:58+00:00"
         },
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-05-06T08:26:05+00:00"
+        },
+        {
             "name": "guzzlehttp/guzzle",
             "version": "7.15.1",
             "source": {
@@ -2227,6 +2323,181 @@
                 "source": "https://github.com/php-webdriver/php-webdriver/tree/1.16.0"
             },
             "time": "2025-12-28T23:57:40+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/39467533fdb742446d68c1d10ac33d625ee0311c",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-07-27T11:13:17+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3959,6 +4230,139 @@
             "time": "2025-02-07T05:00:38+00:00"
         },
         {
+            "name": "sirbrillig/phpcs-changed",
+            "version": "v2.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-changed.git",
+                "reference": "a369fce181a5064b6150708c3b0a1045c518a248"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/a369fce181a5064b6150708c3b0a1045c518a248",
+                "reference": "a369fce181a5064b6150708c3b0a1045c518a248",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1 || ^1.0.0",
+                "phpunit/phpunit": "^6.4 || ^7.0 || ^8.0 || ^9.5",
+                "sirbrillig/phpcs-variable-analysis": "^2.1.3",
+                "squizlabs/php_codesniffer": "^3.2.1",
+                "vimeo/psalm": "^4.24 || ^5.0 || ^6.0"
+            },
+            "bin": [
+                "bin/phpcs-changed"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "PhpcsChanged/Cli.php",
+                    "PhpcsChanged/functions.php"
+                ],
+                "psr-4": {
+                    "PhpcsChanged\\": "PhpcsChanged/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "Run phpcs on files, but only report warnings/errors from lines which were changed.",
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-changed/issues",
+                "source": "https://github.com/sirbrillig/phpcs-changed/tree/v2.13.0"
+            },
+            "time": "2026-04-26T18:04:30+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-08-06T00:17:32+00:00"
+        },
+        {
             "name": "staabm/side-effects-detector",
             "version": "1.0.5",
             "source": {
@@ -5579,6 +5983,72 @@
                 }
             ],
             "time": "2025-12-08T11:19:18+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ec2ff942335f33683a5957a85d138753876a05cf",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
+            },
+            "suggest": {
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-07-27T11:53:23+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b249b68f172db974dd0fc89bddec0d2a",
+    "content-hash": "a695bec1f938de331719637d22ce9970",
     "packages": [
         {
             "name": "automattic/jetpack-assets",
@@ -2323,6 +2323,219 @@
                 "source": "https://github.com/php-webdriver/php-webdriver/tree/1.16.0"
             },
             "time": "2025-12-28T23:57:40+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-19T17:43:28+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/7c8d18b4d90dac9e86b0869a608fa09158e168fa",
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0",
+                "squizlabs/php_codesniffer": "^3.3"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityWP/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-10-18T00:05:59+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",

--- a/scripts/phpcs-changed.sh
+++ b/scripts/phpcs-changed.sh
@@ -45,7 +45,11 @@ case "${1:-}" in
 		;;
 esac
 
-if ! files="$(git diff --diff-filter=d --name-only "${diff_args[@]}" -- '*.php')"; then
+# `${x[@]+"${x[@]}"}` rather than a plain `"${diff_args[@]}"`, because unstaged
+# passes no arguments and bash before 4.4 treats an empty array as unset under
+# `set -u`. macOS ships 3.2, where that aborts the script -- and the `if !` below
+# would have reported it as git failing to read your changes.
+if ! files="$(git diff --diff-filter=d --name-only ${diff_args[@]+"${diff_args[@]}"} -- '*.php')"; then
 	echo "${read_error}" >&2
 	exit 1
 fi

--- a/scripts/phpcs-changed.sh
+++ b/scripts/phpcs-changed.sh
@@ -63,6 +63,11 @@ while IFS= read -r file; do
 	[ -n "${file}" ] && file_list+=( "${file}" )
 done <<< "${files}"
 
+# Say how many files are being looked at. A clean run prints nothing at all
+# otherwise, which leaves silence meaning both "linted and found nothing" and
+# "linted nothing" -- the ambiguity this script exists to remove.
+echo "Linting ${#file_list[@]} changed PHP file(s)..."
+
 # display_errors=stderr for the same reason scripts/phpcs.sh sets it. Nothing
 # parses this process's stdout, so this one is only about legibility: a
 # deprecation printed into the middle of a report is noise you have to read

--- a/scripts/phpcs-changed.sh
+++ b/scripts/phpcs-changed.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Runs phpcs-changed over the PHP files changed in one of three ways, so that
+# only the lines you touched are reported.
+#
+# The three modes were three near-identical one-liners in composer.json. What
+# they have in common is their error handling, and that is the part worth
+# keeping in one place: the shape this replaced was
+#
+#   [[ -n $temp ]] && phpcs-changed ... || echo 'No changes found.'
+#
+# which sent any failure down the `||` branch and exited 0, so lint reported
+# success while linting nothing. One copy is one copy to get right.
+#
+# phpcs itself is reached through scripts/phpcs.sh, which is where the PHP 8.4+
+# deprecation handling lives. See the comment there.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+case "${1:-}" in
+	base)
+		# Three dots, not two. phpcs-changed resolves --git-base to the merge
+		# base, so a two-dot diff here would also queue files that changed on
+		# trunk since the branch point and lint them for nothing.
+		diff_args=( trunk...HEAD )
+		changed_args=( --git-base trunk )
+		read_error="Could not diff against trunk."
+		;;
+	staged)
+		diff_args=( --cached )
+		changed_args=( --git-staged )
+		read_error="Could not read staged changes."
+		;;
+	unstaged)
+		diff_args=()
+		changed_args=( --git-unstaged )
+		read_error="Could not read unstaged changes."
+		;;
+	*)
+		echo "Usage: ${BASH_SOURCE[0]##*/} base|staged|unstaged" >&2
+		exit 2
+		;;
+esac
+
+if ! files="$(git diff --diff-filter=d --name-only "${diff_args[@]}" -- '*.php')"; then
+	echo "${read_error}" >&2
+	exit 1
+fi
+
+if [ -z "${files}" ]; then
+	echo "No PHP changes found."
+	exit 0
+fi
+
+# Read into an array rather than letting the shell split on whitespace, so a
+# path with a space in it is one file and not two. `mapfile` would be tidier,
+# but macOS still ships bash 3.2 and the Makefile runs recipes through it.
+file_list=()
+while IFS= read -r file; do
+	[ -n "${file}" ] && file_list+=( "${file}" )
+done <<< "${files}"
+
+# display_errors=stderr for the same reason scripts/phpcs.sh sets it. Nothing
+# parses this process's stdout, so this one is only about legibility: a
+# deprecation printed into the middle of a report is noise you have to read
+# past to find the violations.
+exec php \
+	-d display_errors=stderr \
+	-d auto_prepend_file="${repo_root}/tests/suppress_php84_deprecations.php" \
+	"${repo_root}/vendor/bin/phpcs-changed" \
+	-s --git "${changed_args[@]}" \
+	--phpcs-path "${repo_root}/scripts/phpcs.sh" \
+	"${file_list[@]}"

--- a/scripts/phpcs.sh
+++ b/scripts/phpcs.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Runs phpcs with PHP 8.4+ deprecations from thecodingmachine/safe suppressed.
+#
+# phpcs boots the project's Composer autoloader, which eagerly loads
+# thecodingmachine/safe's generated function files. On PHP 8.4 and up those
+# emit an implicit-nullable deprecation each, and the notices land on stdout
+# ahead of phpcs's own output. That is fatal for phpcs-changed, which parses
+# phpcs's JSON: it fails to decode, assumes the unmodified file had no errors,
+# and reports every pre-existing violation in the file as though you'd
+# introduced it.
+#
+# So phpcs is never called directly. `composer cs` and friends point
+# phpcs-changed at this wrapper via --phpcs-path.
+#
+# Same fix, and same prepend file, as the phpunit and codecept scripts in
+# composer.json. It goes away when the plugin can drop PHP 7.4 and move to
+# thecodingmachine/safe v2.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+exec php \
+	-d auto_prepend_file="${repo_root}/tests/suppress_php84_deprecations.php" \
+	"${repo_root}/vendor/bin/phpcs" "$@"

--- a/scripts/phpcs.sh
+++ b/scripts/phpcs.sh
@@ -6,9 +6,10 @@
 # thecodingmachine/safe's generated function files. On PHP 8.4 and up those
 # emit an implicit-nullable deprecation each, and the notices land on stdout
 # ahead of phpcs's own output. That is fatal for phpcs-changed, which parses
-# phpcs's JSON: it fails to decode, assumes the unmodified file had no errors,
-# and reports every pre-existing violation in the file as though you'd
-# introduced it.
+# phpcs's JSON: it aborts with `Failed to decode phpcs JSON` and exits 1. The
+# old `composer cs` one-liner sent that failure down its `|| echo 'No changes
+# found.'` branch, which is how a lint run that examined nothing came to report
+# success.
 #
 # So phpcs is never called directly. `composer cs` and friends point
 # phpcs-changed at this wrapper via --phpcs-path.

--- a/scripts/phpcs.sh
+++ b/scripts/phpcs.sh
@@ -21,6 +21,12 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# `display_errors=stderr` is the belt to that braces. The prepend file only
+# silences one known deprecation; anything else PHP has to say -- and
+# PHPCompatibility 9.3.5 is 2019 code running on PHP 8.5 -- would still land on
+# stdout and corrupt the JSON the same way. phpcs-changed captures stdout only,
+# so on stderr a diagnostic stays visible to you without breaking the parse.
 exec php \
+	-d display_errors=stderr \
 	-d auto_prepend_file="${repo_root}/tests/suppress_php84_deprecations.php" \
 	"${repo_root}/vendor/bin/phpcs" "$@"

--- a/tests/suppress_php84_deprecations.php
+++ b/tests/suppress_php84_deprecations.php
@@ -15,7 +15,10 @@ if ( PHP_VERSION_ID >= 80400 ) {
 		function ( $errno, $errstr, $errfile = '' ) {
 			return E_DEPRECATED === $errno
 				&& str_contains( $errstr, 'the explicit nullable type must be used instead' )
-				&& str_contains( $errfile, 'crm/vendor/thecodingmachine/safe/' );
+				// Not `crm/vendor/...`: that only matched because the checkout
+				// happened to be in a directory ending in `crm`. Clone this to
+				// `~/src/jpcrm` and the handler stopped firing.
+				&& str_contains( $errfile, '/vendor/thecodingmachine/safe/' );
 		},
 		E_ALL
 	);


### PR DESCRIPTION
`make lint` and `make test` both failed, and lint was the worse of the two because it reported success while linting nothing at all.

## phpcs

Four faults, all of which had to go before a single sniff ran:

- **No ruleset.** `phpcs.xml.dist` was removed in 469d4320 (April 2023, monorepo cleanup) and never replaced, so phpcs fell back to the PEAR standard and complained about tabs in a WordPress codebase. 744 violations on `ZeroBSCRM.php` alone, none of them meaningful.
- **`phpcs-changed` was never a dependency.** `composer cs` died with `command not found`. It only appeared to work for anyone who happened to have it installed globally.
- **That failure was invisible.** The `[[ -n $temp ]] && phpcs-changed ... || echo 'No changes found.'` shape sent any failure down the `||` branch and exited 0. This is why it looked fine.
- **PHP 8.4+ deprecations corrupted the output.** phpcs boots the project autoloader, which eagerly loads `thecodingmachine/safe`, and that prints a deprecation per generated function onto stdout ahead of phpcs's JSON. `phpcs-changed` can't decode that, so it gives up: `Failed to decode phpcs JSON` on stderr, exit 1. Loud enough on its own. The `||` above sent it down the same branch as a clean run, so what you actually saw was `No changes found.`

So this restores the ruleset, adds phpcs, WPCS and phpcs-changed as dev dependencies, and routes phpcs through `scripts/phpcs.sh`, which applies the same deprecation suppressor the phpunit and codecept scripts already use. `--phpcs-path` takes an executable, which is why it needs a wrapper rather than an inline `php -d`.

The wrapper sets `display_errors=stderr` as well. The suppressor only silences the one deprecation we know about, and phpcs-changed captures stdout only, so anything else PHP has to say stays visible to you without breaking the parse. PHPCompatibility 9.3.5 is 2019 code and it is running on PHP 8.5 here. The suppressor itself matched on `crm/vendor/thecodingmachine/safe/`, which only ever fired because this checkout sits in a directory called `jetpack-crm`; it matches `/vendor/thecodingmachine/safe/` now.

The tree as a whole does not pass the ruleset, which is fine: every entry point goes through phpcs-changed and only reports on the lines you touched. `--always-exit-zero` is dropped so those reports fail the command.

`composer cs`, `cs-staged` and `cs-unstaged` were three copies of the same one-liner, differing in one flag. What they had in common was the error handling, which is the part this PR exists to get right, so they are one `scripts/phpcs-changed.sh base|staged|unstaged` now. It reads the file list into an array rather than letting the shell split it, so a path with a space in it is one file and not two, and it diffs `trunk...HEAD` rather than `trunk HEAD`: phpcs-changed resolves `--git-base` to the merge base, so the two-dot form also queued files that had only changed on trunk. Against a base that has genuinely diverged that is 7 files queued where 1 is wanted.

It also says how many files it is about to look at. A clean run printed nothing at all otherwise, so silence meant both "linted them and found nothing" and "linted nothing", which is the ambiguity this PR exists to remove.

## Excludes

Every `exclude-pattern` in the ruleset is `type="relative"`, and it took three goes to get that right.

A pattern is an unanchored regex, and a plain one is matched against the absolute path. So `*/build/*` cannot tell this checkout's `build/` from an ancestor directory called that: clone this to `~/build/` or `~/dist/` and the tree excludes itself, the walk queues nothing, and phpcs exits 0. `.claude/` is the same hazard from the other side. It holds the worktrees, so an absolute pattern naming it matches every file inside one, which is how `make lint` came to report success in a worktree having examined nothing.

Nothing is given up by making them all relative. These top-level patterns only ever apply to a directory walk: they are read by `Filters/Filter.php`, and phpcs-changed never reaches it, because it pipes each file in on stdin and names it with `stdin-path`. The one behaviour that changes is naming a vendored file explicitly on the command line, which now lints it rather than ignoring you.

The patterns carry a `(^|/)` prefix so that `vendor/*` does not also match a `livevendor/` somewhere in the tree.

The rule-level excludes for `tests/` are a different mechanism, matched in `Files/File.php`, and they carry the same `(^|/)` prefix now. That one is consistency rather than a fix, and I had it wrong twice before landing there. `Files/File.php` ignores the `type` attribute outright and matches whatever path it was handed, and `*/tests/*` compiles to `.*/tests/.*`, which needs a literal `/tests/`. So I assumed phpcs-changed's repo-relative paths never matched and those five sniffs were firing on every test file `make lint` looked at. They weren't. `Config.php:1005` realpaths the `stdin-path` argument and keeps the string it was given only when no such file exists, which phpcs-changed's own `isReadable` guard rules out first. `Files/File.php` gets an absolute path on both entry points, and `*/tests/*` matched all along. What misled me was checking it with `--stdin-path=tests/php/thing.php`, a path that doesn't exist: that is the one case that does fall back to the relative string.

`(^|/)tests/*` is a strict superset of what was there so it stays, but nothing depends on it. Neither shape anchors to the repo root, because an absolute path has to match on the `/` branch. A checkout under a directory called `tests` loses those five sniffs on a walk, which was true before this PR too, and nothing in a pattern can tell that path from a real one. The ruleset comment says so.

`WordPress.Files.FileName` looks like it belongs in that list and does not. The sniff returns early on STDIN (`FileNameSniff.php:155`), so it has never run through phpcs-changed whatever the pattern said.

## bash 3.2

`make lint-unstaged` aborted under the bash macOS ships. unstaged is the mode that passes no arguments to `git diff`, and bash before 4.4 treats an empty array as unset under `set -u`, so 3.2 died on `diff_args[@]: unbound variable`. The `if !` around it then reported that as git failing to read your changes, which points you at the wrong thing entirely. Homebrew bash 5.3 is first on my `PATH`, which is why I did not see it, and it is the same 3.2 that is the reason the script does not use `mapfile`. `${diff_args[@]+"${diff_args[@]}"}` now.

## PHPUnit

Two stacked reasons:

- It ran on the host, where the WordPress test library doesn't exist. You got "Failed to automatically locate WordPress or wordpress-develop".
- `phpunit-select-config` re-execs via `pcntl_exec()`, and `pcntl` isn't loaded in the wp-env image, so it fatals there too.

`make test` now runs inside the tests-cli container with `WORDPRESS_DEVELOP_DIR` set (the container's own `WP_TESTS_DIR` is not the variable `tests/php/bootstrap.php` reads), and the composer script picks the config from `phpunit --version` instead of shelling out through `pcntl`. Takes phpunit flags via `ARGS`:

```
make test
make test ARGS="--testsuite pdf"
make test ARGS="--filter SomeTest"
```

`ARGS` is re-quoted word by word and folded into the single string wp-env is handed. It cannot be passed as separate arguments after the command: wp-env parses its own argv, so anything looking like an option is eaten before the container sees it and `ARGS="--testsuite pdf"` arrives as `pdf` alone. Interpolating it raw does not work either, since the recipe shell has stripped the quotes by then and `ARGS="--filter 'It works'"` splits.

`make test` also probes the container before running, so a stopped environment says so instead of surfacing a raw docker compose error. That is a separate call from the run: folding it in would report a failing test suite as a stopped container.

## Worktrees

Both commands work from a git worktree under `.claude/worktrees/`. Those sit inside the directory wp-env mounts, so the container can see their files, but `vendor/`, `jetpack_vendor/` and `node_modules/` are gitignored and so absent. `make worktree-link` symlinks all three in with relative paths that resolve on both the host and inside the container. Note what that means, and it was already true of `vendor/`: npm and composer run in a worktree write into the main checkout. wp-env itself comes from, and runs in, the main checkout: it keys its state directory on the invocation directory, so calling it in a worktree reports "Environment not initialized" even with the containers up.

Those three are ignored without a trailing slash, since a trailing slash matches directories only and the symlinks were showing up as untracked in every worktree.

A worktree outside the main checkout can't work at all, since wp-env never mounts it. `require_inside` refuses in that case rather than quietly falling back to the main checkout and reporting its results as the worktree's, and `require_vendor` gives one piece of advice when the binary is missing: install in the main checkout, and link if you are in a worktree. Both are one define called from the targets that need them.

A checkout path containing a space is not supported, and the comment says so. An earlier version of this tried: `WORKTREE_REL` was space-safe while `$(abspath)`, `$(notdir)` and the `$(WP_ENV_BIN)` prerequisite either side of it were not, so a spaced checkout classified a worktree under it as outside the main checkout and every wp-env target died claiming wp-env wasn't installed. Half-supporting it was worse than not.

## Verifying

```
make lint                                    # clean tree: "No PHP changes found."
make test                                    # 51 tests, 228 assertions
make test ARGS="--testsuite pdf"             # 14 tests, 24 assertions
make test ARGS="--filter 'Pdf|Nothing Here'" # 14 tests: the space survives
make test ARGS="--filter ZZZNoSuchTest"      # "No tests executed", exit 1
```

The last two are the `ARGS` quoting and the container probe. A filter containing a space reaching phpunit whole is what a split would fail on, and a run that fails on its own merits has to say so rather than blaming the containers.

Then touch a PHP file and run `make lint-unstaged`. You should get `Linting 1 changed PHP file(s)...`, the lines you changed and nothing else, and a non-zero exit.

For the excludes, a walk queues 316 files from the main checkout, and the same from inside a worktree give or take whatever that branch adds:

```
scripts/phpcs.sh -p --parallel=1 --sniffs=Generic.PHP.LowerCaseConstant --report=summary .
```

A copy of the tree placed under a `build/` directory is linted rather than skipped, with its nested `node_modules/` and `.claude/worktrees/` still excluded. The old patterns produced no output and exit 0 there.

For the `tests/` excludes, feed a file in at a path that exists under `tests/` and check the sniffs stay quiet. This one is a docblock whose only description is its `@testdox`:

```
scripts/phpcs.sh --report=full -q --stdin-path=tests/php/bootstrap.php - < some.php
```

Nothing, and the same file at `--stdin-path=includes/thing.php` reports `MissingShort`. Use a path that exists: `--stdin-path=tests/php/thing.php` misses the realpath in `Config.php` and exercises the fallback rather than the thing you want to check.

Run the scripts once under `/bin/bash` rather than whatever `env bash` finds you. That is bash 3.2 on a stock macOS and it is a different language in the places this matters.

In a worktree, `make lint` before `make worktree-link` names both commands and exits 1, and works after it. `make test WORKTREE_ROOT=/somewhere/else` fakes an outside worktree and gets the refusal.

## Notes

`automattic/phpunit-select-config` is unused after this and could be dropped. I've left it in place.

Nothing in `.github/workflows/` runs either phpcs or phpunit, so both remain local-only. Wiring them into CI is worth doing separately, though the ruleset here would need a baseline first.

The README describes `make test` and the lint targets as they are now: that `make test` wants the containers up, the `ARGS` form, the two new lint targets, and the worktree flow with `make worktree-link`.

Four smaller things left alone.

- `-p` reports batch counts rather than file counts when `parallel` is above 1, a phpcs display quirk but a confusing one given the ruleset sets 10.
- `^\.claude/` excludes the files but does not prune the directory. `Filters/Filter.php` only builds a directory pattern from a pattern ending in `/*`, so a walk still descends into every worktree and rejects the files one at a time. The count is right, the walk is slower than it needs to be.
- `base` mode lists what is committed on the branch, while phpcs-changed then diffs the merge base against the working tree. A file with uncommitted changes and nothing committed is not queued. `lint-unstaged` covers it, so this is a wording problem more than a gap.
- The rule-level `tests/` patterns are matched against an absolute path, and an unanchored regex has to allow a leading `/`. So a checkout sitting under a directory called `tests` loses those five sniffs on a full-tree walk. `*/tests/*` and `(^|/)tests/*` are the same in this respect: the prefix neither caused it nor cures it, and nothing in a pattern can tell that path from a real one. The ruleset comment says so.

Shout if any of them is worth doing here rather than later.



