### PR TITLE
Fix Activity panel header icon rendering

### DIFF
--- a/includes/ZeroBSCRM.MetaBox.php
+++ b/includes/ZeroBSCRM.MetaBox.php
@@ -850,7 +850,7 @@ function zeroBSCRM_do_meta_box_html( $box, $page, $hidden, $object, $minimised, 
 		} */
 
 			// txt
-			echo '<div class="header item">' . esc_html( $box['title'] ) . '</div>' . $hideMinimiseMenu . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is hard-coded HTML with no vars.
+			echo '<div class="header item">' . wp_kses( $box['title'], array( 'i' => array( 'class' => true ) ) ) . '</div>' . $hideMinimiseMenu . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Title allows only the expected Semantic UI icon markup.
 
 			// right hand menu, if one
 			/*

--- a/includes/ZeroBSCRM.MetaBox.php
+++ b/includes/ZeroBSCRM.MetaBox.php
@@ -70,7 +70,7 @@ class zeroBS__Metabox {
 
 			// lazy hackaround for now, can be more classy later.
 			if ( ! empty( $this->metaboxIcon ) ) {
-				$this->metaboxTitle = '<i class="' . $this->metaboxIcon . ' icon"></i> ' . $this->metaboxTitle;
+				$this->metaboxTitle = '<i class="' . $this->metaboxIcon . ' icon" aria-hidden="true"></i> ' . $this->metaboxTitle;
 			}
 
 			// self::$instance = $this;
@@ -717,6 +717,22 @@ function zeroBSCRM_do_meta_box_htmlTabHead( $tabsID = '', $tabs = false ) {
 	}
 }
 
+/**
+ * Markup permitted in a metabox title.
+ *
+ * Titles carry the Semantic UI icon markup that initMetabox() prepends, and nothing else.
+ *
+ * @return array Allowed HTML, in wp_kses() format.
+ */
+function jpcrm_metabox_title_allowed_html() {
+	return array(
+		'i' => array(
+			'class'       => true,
+			'aria-hidden' => true,
+		),
+	);
+}
+
 function zeroBSCRM_do_meta_box_html( $box, $page, $hidden, $object, $minimised, $isTabPane = false, $isActiveTab = false ) {
 
 		/*
@@ -850,7 +866,7 @@ function zeroBSCRM_do_meta_box_html( $box, $page, $hidden, $object, $minimised, 
 		} */
 
 			// txt
-			echo '<div class="header item">' . wp_kses( $box['title'], array( 'i' => array( 'class' => true ) ) ) . '</div>' . $hideMinimiseMenu . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Title allows only the expected Semantic UI icon markup.
+			echo '<div class="header item">' . wp_kses( $box['title'], jpcrm_metabox_title_allowed_html() ) . '</div>' . $hideMinimiseMenu . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Title allows only the expected Semantic UI icon markup.
 
 			// right hand menu, if one
 			/*
@@ -878,7 +894,7 @@ function zeroBSCRM_do_meta_box_html( $box, $page, $hidden, $object, $minimised, 
 			echo '<div id="' . esc_attr( $box['id'] ) . '-box" class="zbs-metabox-body ' . esc_attr( $htmlClasses ) . ' ' . esc_attr( $extraClasses ) . '">' . "\n"; // $hidden_class.
 				call_user_func( $box['callback'], $object, $box );
 			echo '</div>'; // /.zbs-metabox-body
-			echo '<div id="' . esc_attr( $box['id'] ) . '-block" class="zbs-metabox-block"><div>' . wp_kses( $box['title'], array( 'i' => array( 'class' => true ) ) ) . '</div></div>'; // this is BLOCKER for drag-drop support -//<i class="arrows alternate icon"></i>
+			echo '<div id="' . esc_attr( $box['id'] ) . '-block" class="zbs-metabox-block"><div>' . wp_kses( $box['title'], jpcrm_metabox_title_allowed_html() ) . '</div></div>'; // this is BLOCKER for drag-drop support -//<i class="arrows alternate icon"></i>
 		echo "</div>\n";
 }
 

--- a/includes/ZeroBSCRM.MetaBox.php
+++ b/includes/ZeroBSCRM.MetaBox.php
@@ -878,7 +878,7 @@ function zeroBSCRM_do_meta_box_html( $box, $page, $hidden, $object, $minimised, 
 			echo '<div id="' . esc_attr( $box['id'] ) . '-box" class="zbs-metabox-body ' . esc_attr( $htmlClasses ) . ' ' . esc_attr( $extraClasses ) . '">' . "\n"; // $hidden_class.
 				call_user_func( $box['callback'], $object, $box );
 			echo '</div>'; // /.zbs-metabox-body
-			echo '<div id="' . esc_attr( $box['id'] ) . '-block" class="zbs-metabox-block"><div>' . esc_html( $box['title'] ) . '</div></div>'; // this is BLOCKER for drag-drop support -//<i class="arrows alternate icon"></i>
+			echo '<div id="' . esc_attr( $box['id'] ) . '-block" class="zbs-metabox-block"><div>' . wp_kses( $box['title'], array( 'i' => array( 'class' => true ) ) ) . '</div></div>'; // this is BLOCKER for drag-drop support -//<i class="arrows alternate icon"></i>
 		echo "</div>\n";
 }
 

--- a/includes/ZeroBSCRM.MetaBox.php
+++ b/includes/ZeroBSCRM.MetaBox.php
@@ -866,7 +866,7 @@ function zeroBSCRM_do_meta_box_html( $box, $page, $hidden, $object, $minimised, 
 		} */
 
 			// txt
-			echo '<div class="header item">' . wp_kses( $box['title'], jpcrm_metabox_title_allowed_html() ) . '</div>' . $hideMinimiseMenu . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Title allows only the expected Semantic UI icon markup.
+			echo '<div class="header item">' . wp_kses( $box['title'], jpcrm_metabox_title_allowed_html() ) . '</div>' . $hideMinimiseMenu . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $hideMinimiseMenu is hard-coded markup; the title is escaped by wp_kses() above.
 
 			// right hand menu, if one
 			/*


### PR DESCRIPTION
## Summary

Fixes the Activity panel header on Contact and Company records so the heartbeat icon renders instead of appearing as literal HTML.

The metabox title intentionally contains Semantic UI icon markup, but `esc_html()` escaped that markup. This change uses a narrow `wp_kses()` allowlist that permits only the expected `<i>` element and its `class` attribute.

Related issue: [JETCRM-1445](https://linear.app/a8c/issue/JETCRM-1445/crm-activity-panel-header-for-contact-sna-companies-renders-raw-icon)

## Testing

1. Opened Jetpack CRM → Contacts and opened a contact.
2. Confirmed the Activity panel displays the heartbeat icon followed by
   “Activity”.
3. Confirmed the raw `<i class="heartbeat icon"></i>` text is no longer
   displayed.
4. Opened Jetpack CRM → Companies and opened a company.
5. Confirmed the Activity panel displays correctly there as well.
6. Confirmed the Activity panel can still be minimized and reopened.

## Escaping history (added by @donncha)

This narrows an `esc_html()` that was added deliberately. `34c3d199` ("CRM: Improve string sanitization and escaping") escaped the metabox title as part of a hardening pass, which is what stopped the icon rendering. Relaxing it back to a `wp_kses()` allowlist is a scoped revert of that commit, so it is worth writing down why it is safe:

- Every metabox title in the plugin is a hardcoded or translated string, apart from the custom file slot names used by `zeroBS__Metabox_ContactCustomFiles`. Those go through `sanitize_text_field()` on save, so tag markup is stripped before it is ever stored.
- The allowlist permits `<i>` with `class` and `aria-hidden` only. `wp_kses_hair()` drops every other attribute, `on*` handlers included, so the worst an attacker who could write a title would get is an extra CSS class.
- The same allowlist is already used for log descriptions in `ZeroBSCRM.FormatHelpers.php`, so this is the existing pattern rather than a new one.

If you are doing an escaping sweep and this line looks wrong, please read the above before retightening it. The underlying problem is that `initMetabox()` concatenates icon markup into the title string at all, which is tracked in #38.
