### PR TITLE
Carry the metabox icon as its own field

### DIFF
--- a/includes/ZeroBSCRM.MetaBox.php
+++ b/includes/ZeroBSCRM.MetaBox.php
@@ -68,11 +68,6 @@ class zeroBS__Metabox {
 
 		if ( $this->live ) {
 
-			// lazy hackaround for now, can be more classy later.
-			if ( ! empty( $this->metaboxIcon ) ) {
-				$this->metaboxTitle = '<i class="' . $this->metaboxIcon . ' icon" aria-hidden="true"></i> ' . $this->metaboxTitle;
-			}
-
 			// self::$instance = $this;
 
 			// Create on init, for zbs metaboxes, rather than: add_action( 'add_meta_boxes', array( $this, 'create_meta_box' ) );
@@ -114,7 +109,8 @@ class zeroBS__Metabox {
 						array(),
 						$this->headless,
 						$this->metaboxClasses,
-						$this->capabilities
+						$this->capabilities,
+						$this->metaboxIcon // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 					);
 
 				}
@@ -132,7 +128,8 @@ class zeroBS__Metabox {
 				array(),
 				$this->headless,
 				$this->metaboxClasses,
-				$this->capabilities
+				$this->capabilities,
+				$this->metaboxIcon // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			);
 
 		}
@@ -293,9 +290,26 @@ class zeroBS__Metabox {
 	Global metabox helper funcs
 	====================================================== */
 
-// ZBS splintered version of add_meta_box (wholly our own from now on, do not assume can be swapped out directly, may need integration)
-// https://developer.wordpress.org/reference/functions/add_meta_box/
-function zeroBSCRM_add_meta_box( $id, $title, $callback, $screen = null, $context = 'advanced', $priority = 'default', $callback_args = null, $headless = false, $extraClasses = '', $capabilities = false ) {
+/**
+ * ZBS splintered version of add_meta_box.
+ *
+ * Wholly our own from now on, do not assume it can be swapped out directly, it may need integration.
+ * https://developer.wordpress.org/reference/functions/add_meta_box/
+ *
+ * @param string       $id            Metabox ID, unique per screen.
+ * @param string       $title         Title, as plain text. Escaped at render.
+ * @param callable     $callback      Prints the box body.
+ * @param string|array $screen        Screen ID, or an array of them to register the box against several.
+ * @param string       $context       Area of the screen: normal or side.
+ * @param string       $priority      high, core, default, low, or sorted.
+ * @param array        $callback_args Passed through to the callback.
+ * @param bool         $headless      Hides the header.
+ * @param string       $extraClasses  Extra classes for the wrappers.
+ * @param array|false  $capabilities  What the user may do with the box. False for the defaults.
+ * @param string       $icon          Semantic UI icon name, e.g. 'heartbeat'. Empty for no icon.
+ * @return void
+ */
+function zeroBSCRM_add_meta_box( $id, $title, $callback, $screen = null, $context = 'advanced', $priority = 'default', $callback_args = null, $headless = false, $extraClasses = '', $capabilities = false, $icon = '' ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- Legacy names, renaming them would break third-party callers.
 
 	// $id, $title, $callback,$headless
 	// echo 'zeroBSCRM_add_meta_box '.$id.':<pre>'; print_r(array('head'=>$headless)); echo '</pre>';
@@ -312,7 +326,7 @@ function zeroBSCRM_add_meta_box( $id, $title, $callback, $screen = null, $contex
 		$screen = convert_to_screen( $screen );
 	} elseif ( is_array( $screen ) ) {
 		foreach ( $screen as $single_screen ) {
-			zeroBSCRM_add_meta_box( $id, $title, $callback, $single_screen, $context, $priority, $callback_args, $headless, $extraClasses, $capabilities );
+			zeroBSCRM_add_meta_box( $id, $title, $callback, $single_screen, $context, $priority, $callback_args, $headless, $extraClasses, $capabilities, $icon ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- $extraClasses is a legacy parameter name.
 		}
 	}
 
@@ -369,6 +383,8 @@ function zeroBSCRM_add_meta_box( $id, $title, $callback, $screen = null, $contex
 				$headless      = $zbs->metaboxes[ $page ][ $a_context ][ $a_priority ][ $id ]['headless'];
 				$extraClasses  = $zbs->metaboxes[ $page ][ $a_context ][ $a_priority ][ $id ]['extraclasses'];
 				$capabilities  = $zbs->metaboxes[ $page ][ $a_context ][ $a_priority ][ $id ]['capabilities'];
+				// Unlike the six above, nothing registered before this change has an icon key.
+				$icon = $zbs->metaboxes[ $page ][ $a_context ][ $a_priority ][ $id ]['icon'] ?? '';
 			}
 			// An id can be in only one priority and one context.
 			if ( $priority != $a_priority || $context != $a_context ) {
@@ -402,6 +418,7 @@ function zeroBSCRM_add_meta_box( $id, $title, $callback, $screen = null, $contex
 	$zbs->metaboxes[ $page ][ $context ][ $priority ][ $id ] = array(
 		'id'           => $id,
 		'title'        => $title,
+		'icon'         => $icon,
 		'callback'     => $callback,
 		'args'         => $callback_args,
 		'headless'     => $headless,
@@ -689,6 +706,24 @@ function zeroBSCRM_applyScreenOptions( $screenOpts = false, $page = '', $context
 	}
 }
 
+/**
+ * Builds the leading icon for a metabox title, if the box has one.
+ *
+ * Decorative: the title beside it already says what the box is, so it is hidden
+ * from screen readers. Includes its own trailing space, so callers can
+ * concatenate it in front of an escaped title unconditionally.
+ *
+ * @param array $box A metabox as stored in $zbs->metaboxes.
+ * @return string Icon HTML, or an empty string if the box has no icon.
+ */
+function jpcrm_metabox_icon_html( $box ) {
+	if ( empty( $box['icon'] ) ) {
+		return '';
+	}
+
+	return '<i class="' . esc_attr( $box['icon'] ) . ' icon" aria-hidden="true"></i> ';
+}
+
 // https://semantic-ui.com/modules/tab.html#/examples
 function zeroBSCRM_do_meta_box_htmlTabHead( $tabsID = '', $tabs = false ) {
 
@@ -707,7 +742,7 @@ function zeroBSCRM_do_meta_box_htmlTabHead( $tabsID = '', $tabs = false ) {
 			if ( $indx == 0 ) {
 				echo ' active';
 			}
-			echo '" data-tab="' . esc_attr( $subbox['id'] ) . '">' . esc_html( $subbox['title'] ) . '</a>';
+			echo '" data-tab="' . esc_attr( $subbox['id'] ) . '">' . jpcrm_metabox_icon_html( $subbox ) . esc_html( $subbox['title'] ) . '</a>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- jpcrm_metabox_icon_html() escapes what it interpolates.
 			++$indx;
 
 		}
@@ -715,22 +750,6 @@ function zeroBSCRM_do_meta_box_htmlTabHead( $tabsID = '', $tabs = false ) {
 		echo '</div>';
 
 	}
-}
-
-/**
- * Markup permitted in a metabox title.
- *
- * Titles carry the Semantic UI icon markup that initMetabox() prepends, and nothing else.
- *
- * @return array Allowed HTML, in wp_kses() format.
- */
-function jpcrm_metabox_title_allowed_html() {
-	return array(
-		'i' => array(
-			'class'       => true,
-			'aria-hidden' => true,
-		),
-	);
 }
 
 function zeroBSCRM_do_meta_box_html( $box, $page, $hidden, $object, $minimised, $isTabPane = false, $isActiveTab = false ) {
@@ -866,7 +885,7 @@ function zeroBSCRM_do_meta_box_html( $box, $page, $hidden, $object, $minimised, 
 		} */
 
 			// txt
-			echo '<div class="header item">' . wp_kses( $box['title'], jpcrm_metabox_title_allowed_html() ) . '</div>' . $hideMinimiseMenu . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $hideMinimiseMenu is hard-coded markup; the title is escaped by wp_kses() above.
+			echo '<div class="header item">' . jpcrm_metabox_icon_html( $box ) . esc_html( $box['title'] ) . '</div>' . $hideMinimiseMenu . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- $hideMinimiseMenu is hard-coded markup, and jpcrm_metabox_icon_html() escapes what it interpolates.
 
 			// right hand menu, if one
 			/*
@@ -894,7 +913,7 @@ function zeroBSCRM_do_meta_box_html( $box, $page, $hidden, $object, $minimised, 
 			echo '<div id="' . esc_attr( $box['id'] ) . '-box" class="zbs-metabox-body ' . esc_attr( $htmlClasses ) . ' ' . esc_attr( $extraClasses ) . '">' . "\n"; // $hidden_class.
 				call_user_func( $box['callback'], $object, $box );
 			echo '</div>'; // /.zbs-metabox-body
-			echo '<div id="' . esc_attr( $box['id'] ) . '-block" class="zbs-metabox-block"><div>' . wp_kses( $box['title'], jpcrm_metabox_title_allowed_html() ) . '</div></div>'; // this is BLOCKER for drag-drop support -//<i class="arrows alternate icon"></i>
+			echo '<div id="' . esc_attr( $box['id'] ) . '-block" class="zbs-metabox-block"><div>' . jpcrm_metabox_icon_html( $box ) . esc_html( $box['title'] ) . '</div></div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- jpcrm_metabox_icon_html() escapes what it interpolates. This is the BLOCKER that covers the box during drag-drop.
 		echo "</div>\n";
 }
 

--- a/includes/ZeroBSCRM.ScreenOptions.php
+++ b/includes/ZeroBSCRM.ScreenOptions.php
@@ -11,6 +11,50 @@
 
 defined( 'ZEROBSCRM_PATH' ) || exit( 0 );
 
+/**
+ * Builds one show/hide column of the screen options metabox list.
+ *
+ * @param array  $metaboxes Metaboxes for one context, keyed by metabox ID.
+ * @param array  $hidden    IDs of the metaboxes the user has hidden.
+ * @param string $heading   Column heading, already translated.
+ * @return string
+ */
+function jpcrm_screen_options_metabox_list_html( $metaboxes, $hidden, $heading ) {
+
+	// One full-width column each. This was a ten/six wide split once.
+	$html = '<div class="sixteen wide column"><h4 class="ui header">' . esc_html( $heading ) . '</h4>';
+
+	foreach ( $metaboxes as $metabox_id => $metabox ) {
+
+		// Fall back to the ID, which is at least something to click.
+		$title = $metabox_id;
+		if ( is_array( $metabox ) && isset( $metabox['title'] ) ) {
+			$title = $metabox['title'];
+		}
+
+		$can_hide = true;
+		if ( isset( $metabox['capabilities']['can_hide'] ) && ! $metabox['capabilities']['can_hide'] ) {
+			$can_hide = false;
+		}
+
+		$label = jpcrm_metabox_icon_html( $metabox ) . esc_html( $title );
+
+		$html .= '<div class="ui checkbox zbs-metabox-checkbox"><input type="checkbox" id="zbs-mb-' . esc_attr( $metabox_id ) . '"';
+
+		if ( ! $can_hide ) {
+			$html .= ' checked="checked" disabled="disabled"';
+			// Cast, because PHP has already turned a numeric ID into an int on the
+			// way into the array key, and the stored screen option holds strings.
+		} elseif ( ! in_array( (string) $metabox_id, $hidden, true ) ) {
+			$html .= ' checked="checked"';
+		}
+
+		$html .= ' /><label for="zbs-mb-' . esc_attr( $metabox_id ) . '">' . $label . '</label></div>';
+	}
+
+	return $html . '</div>';
+}
+
 // outputs top of page screen options panel :)
 // (based on rights + pagekey)
 function zeroBSCRM_screenOptionsPanel() {
@@ -77,69 +121,13 @@ function zeroBSCRM_screenOptionsPanel() {
 				// show lists - normal
 			if ( isset( $options['metaboxes']['normal'] ) && is_array( $options['metaboxes']['normal'] ) && count( $options['metaboxes']['normal'] ) > 0 ) {
 
-				// for now, just doing lines $screenOptionsHTML .= '<div class="ten wide column">';
-				$screenOptionsHTML .= '<div class="sixteen wide column"><h4 class="ui header">' . __( 'Main Column', 'zero-bs-crm' ) . '</h4>';
-				foreach ( $options['metaboxes']['normal'] as $mbID => $mb ) {
-
-					$mbTitle = $mbID;
-					if ( is_array( $mb ) && isset( $mb['title'] ) ) {
-						$mbTitle = $mb['title'];
-					}
-
-					// if can hide
-					$canHide = true;
-					if ( isset( $mb['capabilities'] ) && isset( $mb['capabilities']['can_hide'] ) && $mb['capabilities']['can_hide'] == false ) {
-						$canHide = false;
-					}
-
-					if ( $canHide ) {
-
-						$screenOptionsHTML .= '<div class="ui checkbox zbs-metabox-checkbox"><input type="checkbox" id="zbs-mb-' . $mbID . '"';
-						if ( ! in_array( $mbID, $hidden ) ) {
-							$screenOptionsHTML .= ' checked="checked"';
-						}
-						$screenOptionsHTML .= ' /><label for="zbs-mb-' . $mbID . '">' . $mbTitle . '</label></div>';
-
-					} else {
-
-						$screenOptionsHTML .= '<div class="ui checkbox zbs-metabox-checkbox"><input type="checkbox" id="zbs-mb-' . $mbID . '" checked="checked" disabled="disabled"><label for="zbs-mb-' . $mbID . '">' . $mbTitle . '</label></div>';
-
-					}
-				}
-				$screenOptionsHTML .= '</div>';
+				$screenOptionsHTML .= jpcrm_screen_options_metabox_list_html( $options['metaboxes']['normal'], $hidden, __( 'Main Column', 'zero-bs-crm' ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- $screenOptionsHTML is a legacy variable name.
 
 			}
 				// show list - side
 			if ( isset( $options['metaboxes']['side'] ) && is_array( $options['metaboxes']['side'] ) && count( $options['metaboxes']['side'] ) > 0 ) {
 
-				// for now, just doing lines $screenOptionsHTML .= '<div class="six wide column">';
-				$screenOptionsHTML .= '<div class="sixteen wide column"><h4 class="ui header">' . __( 'Side', 'zero-bs-crm' ) . '</h4>';
-				foreach ( $options['metaboxes']['side'] as $mbID => $mb ) {
-
-					$mbTitle = $mbID;
-					if ( is_array( $mb ) && isset( $mb['title'] ) ) {
-						$mbTitle = $mb['title'];
-					}
-
-					// if can hide
-					$canHide = true;
-					if ( isset( $mb['capabilities'] ) && isset( $mb['capabilities']['can_hide'] ) && $mb['capabilities']['can_hide'] == false ) {
-						$canHide = false;
-					}
-
-					if ( $canHide ) {
-						$screenOptionsHTML .= '<div class="ui checkbox zbs-metabox-checkbox"><input type="checkbox" id="zbs-mb-' . $mbID . '"';
-						if ( ! in_array( $mbID, $hidden ) ) {
-							$screenOptionsHTML .= ' checked="checked"';
-						}
-						$screenOptionsHTML .= ' /><label for="zbs-mb-' . $mbID . '">' . $mbTitle . '</label></div>';
-					} else {
-
-						$screenOptionsHTML .= '<div class="ui checkbox zbs-metabox-checkbox"><input type="checkbox" id="zbs-mb-' . $mbID . '" checked="checked" disabled="disabled"><label for="zbs-mb-' . $mbID . '">' . $mbTitle . '</label></div>';
-
-					}
-				}
-				$screenOptionsHTML .= '</div>';
+				$screenOptionsHTML .= jpcrm_screen_options_metabox_list_html( $options['metaboxes']['side'], $hidden, __( 'Side', 'zero-bs-crm' ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- $screenOptionsHTML is a legacy variable name.
 
 			}
 

--- a/phpunit.11.xml.dist
+++ b/phpunit.11.xml.dist
@@ -31,6 +31,9 @@
 		<testsuite name="pdf">
 			<directory suffix="Test.php">tests/php/pdf</directory>
 		</testsuite>
+		<testsuite name="metabox">
+			<directory suffix="Test.php">tests/php/metabox</directory>
+		</testsuite>
 	</testsuites>
 
 	<source>

--- a/phpunit.9.xml.dist
+++ b/phpunit.9.xml.dist
@@ -22,5 +22,8 @@
 		<testsuite name="pdf">
 			<directory suffix="Test.php">tests/php/pdf</directory>
 		</testsuite>
+		<testsuite name="metabox">
+			<directory suffix="Test.php">tests/php/metabox</directory>
+		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/php/metabox/Metabox_Icon_Test.php
+++ b/tests/php/metabox/Metabox_Icon_Test.php
@@ -155,6 +155,31 @@ class Metabox_Icon_Test extends JPCRM_Base_TestCase {
 		$this->assertSame( 'heartbeat', $zbs->metaboxes['zbs-view-company']['side']['high']['zbs-test-box']['icon'] );
 	}
 
+	/**
+	 * Re-registering at 'sorted' priority carries the icon over with the title.
+	 *
+	 * A 'sorted' caller passes no title, callback or icon: the box is being moved
+	 * to where the user dragged it, so those are read back off the existing
+	 * registration. Miss the icon there and a dragged box loses it. The only
+	 * caller is commented out today, which is exactly why this needs pinning.
+	 */
+	public function test_add_meta_box_keeps_the_icon_when_re_registering_as_sorted() {
+		global $zbs;
+
+		zeroBSCRM_add_meta_box( 'zbs-test-box', 'Activity', '__return_null', 'zbs-view-contact', 'side', 'high', array(), false, '', false, 'heartbeat' );
+
+		// The shape the sorted caller uses: id, screen, context and 'sorted', nothing else.
+		zeroBSCRM_add_meta_box( 'zbs-test-box', null, null, 'zbs-view-contact', 'side', 'sorted' );
+
+		$box = $zbs->metaboxes['zbs-view-contact']['side']['sorted']['zbs-test-box'];
+
+		$this->assertSame( 'heartbeat', $box['icon'] );
+		$this->assertSame( 'Activity', $box['title'] );
+
+		// The box moved priority rather than being duplicated.
+		$this->assertArrayNotHasKey( 'zbs-test-box', $zbs->metaboxes['zbs-view-contact']['side']['high'] );
+	}
+
 
 	/**
 	 * Init no longer prepends icon markup to the title.

--- a/tests/php/metabox/Metabox_Icon_Test.php
+++ b/tests/php/metabox/Metabox_Icon_Test.php
@@ -1,0 +1,348 @@
+<?php
+/**
+ * Tests for metabox icons being carried as their own field.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Metabox\Tests;
+
+use Automattic\Jetpack\CRM\Tests\JPCRM_Base_TestCase;
+use zeroBS__Metabox;
+
+/**
+ * Metaboxes used to have their icon markup concatenated into the title string,
+ * which made every render point an HTML sink. These tests pin the replacement:
+ * the icon is its own key on the box, and titles are plain text.
+ */
+class Metabox_Icon_Test extends JPCRM_Base_TestCase {
+
+	/**
+	 * Reset the metabox registry and load what wp-admin brings.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		// zeroBSCRM_add_meta_box() and the render functions both reach into
+		// wp-admin, which the test bootstrap does not load for us.
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		require_once ABSPATH . 'wp-admin/includes/template.php';
+
+		global $zbs;
+		$zbs->metaboxes = array();
+	}
+
+	/**
+	 * Render a metabox and hand back the HTML it echoed.
+	 *
+	 * @param array  $box  A box array as stored in $zbs->metaboxes.
+	 * @param string $page Screen the box is being rendered on.
+	 * @return string
+	 */
+	private function render_box( array $box, string $page = 'zbs-view-contact' ): string {
+		ob_start();
+		zeroBSCRM_do_meta_box_html( $box, $page, array(), null, array() );
+		return ob_get_clean();
+	}
+
+	/**
+	 * Build a box array of the shape zeroBSCRM_add_meta_box() stores.
+	 *
+	 * @param array $overrides Keys to override on the default box.
+	 * @return array
+	 */
+	private function make_box( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'id'           => 'zbs-test-box',
+				'title'        => 'Activity',
+				'icon'         => 'heartbeat',
+				'callback'     => '__return_null',
+				'args'         => array(),
+				'headless'     => false,
+				'extraclasses' => '',
+				'capabilities' => array( 'can_minimise' => true ),
+			),
+			$overrides
+		);
+	}
+
+
+	/**
+	 * A box without an icon key gets no icon markup.
+	 */
+	public function test_icon_html_is_empty_when_the_box_has_no_icon_key() {
+		$this->assertSame( '', jpcrm_metabox_icon_html( array() ) );
+	}
+
+	/**
+	 * An empty icon gets no icon markup either.
+	 */
+	public function test_icon_html_is_empty_when_the_icon_is_an_empty_string() {
+		$this->assertSame( '', jpcrm_metabox_icon_html( array( 'icon' => '' ) ) );
+	}
+
+	/**
+	 * An icon renders as a Semantic UI <i>, hidden from screen readers.
+	 */
+	public function test_icon_html_renders_a_decorative_semantic_ui_icon() {
+		$this->assertSame(
+			'<i class="heartbeat icon" aria-hidden="true"></i> ',
+			jpcrm_metabox_icon_html( array( 'icon' => 'heartbeat' ) )
+		);
+	}
+
+	/**
+	 * The icon name is escaped, so it cannot break out of the class attribute.
+	 */
+	public function test_icon_html_escapes_the_class_attribute() {
+		$html = jpcrm_metabox_icon_html( array( 'icon' => 'heartbeat" onmouseover="alert(1)' ) );
+
+		// Nothing may escape the class attribute, so the whole thing is one value.
+		$this->assertSame(
+			'<i class="heartbeat&quot; onmouseover=&quot;alert(1) icon" aria-hidden="true"></i> ',
+			$html
+		);
+	}
+
+
+	/**
+	 * Registration keeps the icon and the title apart.
+	 */
+	public function test_add_meta_box_stores_the_icon_alongside_the_title() {
+		global $zbs;
+
+		zeroBSCRM_add_meta_box( 'zbs-test-box', 'Activity', '__return_null', 'zbs-view-contact', 'side', 'high', array(), false, '', false, 'heartbeat' );
+
+		$box = $zbs->metaboxes['zbs-view-contact']['side']['high']['zbs-test-box'];
+
+		$this->assertSame( 'heartbeat', $box['icon'] );
+		$this->assertSame( 'Activity', $box['title'] );
+	}
+
+	/**
+	 * Callers that pass no icon still get an icon key.
+	 */
+	public function test_add_meta_box_defaults_the_icon_to_an_empty_string() {
+		global $zbs;
+
+		zeroBSCRM_add_meta_box( 'zbs-test-box', 'Activity', '__return_null', 'zbs-view-contact', 'side', 'high' );
+
+		$this->assertSame( '', $zbs->metaboxes['zbs-view-contact']['side']['high']['zbs-test-box']['icon'] );
+	}
+
+	/**
+	 * Registering against an array of screens keeps the icon on each.
+	 */
+	public function test_add_meta_box_keeps_the_icon_when_registering_against_several_screens() {
+		global $zbs;
+
+		zeroBSCRM_add_meta_box(
+			'zbs-test-box',
+			'Activity',
+			'__return_null',
+			array( 'zbs-view-contact', 'zbs-view-company' ),
+			'side',
+			'high',
+			array(),
+			false,
+			'',
+			false,
+			'heartbeat'
+		);
+
+		$this->assertSame( 'heartbeat', $zbs->metaboxes['zbs-view-contact']['side']['high']['zbs-test-box']['icon'] );
+		$this->assertSame( 'heartbeat', $zbs->metaboxes['zbs-view-company']['side']['high']['zbs-test-box']['icon'] );
+	}
+
+
+	/**
+	 * Init no longer prepends icon markup to the title.
+	 */
+	public function test_init_metabox_leaves_the_title_as_plain_text() {
+		global $zbs;
+
+		$metabox                  = new class() extends zeroBS__Metabox {}; // phpcs:ignore Squiz.WhiteSpace.SemicolonSpacing.Incorrect
+		$metabox->metaboxID       = 'zbs-test-box';
+		$metabox->metaboxTitle    = 'Activity';
+		$metabox->metaboxIcon     = 'heartbeat';
+		$metabox->metaboxScreen   = 'zbs-view-contact';
+		$metabox->metaboxArea     = 'side';
+		$metabox->metaboxLocation = 'high';
+		$metabox->initMetabox();
+
+		$this->assertSame( 'Activity', $metabox->metaboxTitle );
+
+		$box = $zbs->metaboxes['zbs-view-contact']['side']['high']['zbs-test-box'];
+		$this->assertSame( 'Activity', $box['title'] );
+		$this->assertSame( 'heartbeat', $box['icon'] );
+	}
+
+	/**
+	 * Register one of the shipped icon-bearing metaboxes and check what it produces.
+	 *
+	 * The box body is not what these tests are about, so the callback is swapped
+	 * out before rendering: it wants a real contact or company to report on.
+	 *
+	 * @param string $class_name Metabox class.
+	 * @param string $screen     Screen it registers against.
+	 * @param string $metabox_id Its metabox ID.
+	 */
+	private function assert_shipped_metabox_renders_its_icon( $class_name, $screen, $metabox_id ): void {
+		global $zbs;
+
+		new $class_name( ZBS_ROOTFILE );
+
+		$box = $zbs->metaboxes[ $screen ]['side']['high'][ $metabox_id ];
+
+		$this->assertSame( 'heartbeat', $box['icon'] );
+		$this->assertStringNotContainsString( '<i', $box['title'] );
+
+		$box['callback'] = '__return_null';
+
+		$html = $this->render_box( $box, $screen );
+
+		$this->assertStringContainsString( '<i class="heartbeat icon" aria-hidden="true"></i> ', $html );
+		$this->assertStringNotContainsString( '&lt;i class=', $html );
+	}
+
+	/**
+	 * The shipped contact Activity metabox still shows its heartbeat.
+	 */
+	public function test_contact_activity_metabox_registers_and_renders_its_icon() {
+		$this->assert_shipped_metabox_renders_its_icon(
+			\zeroBS__Metabox_Contact_Activity::class,
+			'zbs-view-contact',
+			'zbs-contact-activity-metabox'
+		);
+	}
+
+	/**
+	 * The shipped company Activity metabox still shows its heartbeat.
+	 */
+	public function test_company_activity_metabox_registers_and_renders_its_icon() {
+		$this->assert_shipped_metabox_renders_its_icon(
+			\zeroBS__Metabox_Company_Activity::class,
+			'zerobs_view_company',
+			'zbs-company-activity-metabox'
+		);
+	}
+
+
+	/**
+	 * The box header renders the icon in front of the title.
+	 */
+	public function test_metabox_header_renders_the_icon() {
+		$html = $this->render_box( $this->make_box() );
+
+		$this->assertStringContainsString( '<i class="heartbeat icon" aria-hidden="true"></i> Activity', $html );
+	}
+
+	/**
+	 * The box header escapes the title.
+	 */
+	public function test_metabox_header_escapes_the_title() {
+		$html = $this->render_box( $this->make_box( array( 'title' => 'Activity <script>alert(1)</script>' ) ) );
+
+		$this->assertStringNotContainsString( '<script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+	}
+
+	/**
+	 * The drag-drop blocker overlay renders the icon and escapes the title.
+	 */
+	public function test_drag_blocker_renders_the_icon_and_escapes_the_title() {
+		$html = $this->render_box( $this->make_box( array( 'title' => 'Activity <b>x</b>' ) ) );
+
+		// The blocker is the element that covers a box while metaboxes are dragged.
+		$this->assertMatchesRegularExpression(
+			'~class="zbs-metabox-block"><div><i class="heartbeat icon" aria-hidden="true"></i> Activity &lt;b&gt;x&lt;/b&gt;</div>~',
+			$html
+		);
+	}
+
+	/**
+	 * A headless box has no header, but its blocker still shows the icon.
+	 */
+	public function test_headless_metabox_still_renders_the_blocker_icon() {
+		$html = $this->render_box( $this->make_box( array( 'headless' => true ) ) );
+
+		$this->assertStringNotContainsString( 'zbs-metabox-head', $html );
+		$this->assertStringContainsString( '<i class="heartbeat icon" aria-hidden="true"></i> Activity', $html );
+	}
+
+	/**
+	 * A tab head renders the icon and escapes the title.
+	 */
+	public function test_tab_head_renders_the_icon_and_escapes_the_title() {
+		ob_start();
+		zeroBSCRM_do_meta_box_htmlTabHead(
+			'zbs-test-tabs',
+			array(
+				'boxes' => array(
+					$this->make_box( array( 'title' => 'Activity <b>x</b>' ) ),
+				),
+			)
+		);
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( '<i class="heartbeat icon" aria-hidden="true"></i> Activity &lt;b&gt;x&lt;/b&gt;', $html );
+	}
+
+
+	/**
+	 * The screen options list renders the icon and escapes the title.
+	 */
+	public function test_screen_options_list_renders_the_icon_and_escapes_the_title() {
+		$html = jpcrm_screen_options_metabox_list_html(
+			array( 'zbs-test-box' => $this->make_box( array( 'title' => 'Activity <b>x</b>' ) ) ),
+			array(),
+			'Main Column'
+		);
+
+		$this->assertStringContainsString( '<i class="heartbeat icon" aria-hidden="true"></i> Activity &lt;b&gt;x&lt;/b&gt;', $html );
+		$this->assertStringNotContainsString( '<b>x</b>', $html );
+	}
+
+	/**
+	 * The screen options list escapes the metabox ID it puts in attributes.
+	 */
+	public function test_screen_options_list_escapes_the_metabox_id() {
+		$html = jpcrm_screen_options_metabox_list_html(
+			array( 'zbs-test"box' => $this->make_box() ),
+			array(),
+			'Main Column'
+		);
+
+		$this->assertStringNotContainsString( 'id="zbs-mb-zbs-test"box"', $html );
+		$this->assertStringContainsString( 'zbs-test&quot;box', $html );
+	}
+
+	/**
+	 * A hidden metabox comes back unchecked.
+	 */
+	public function test_screen_options_list_marks_a_hidden_metabox_unchecked() {
+		$html = jpcrm_screen_options_metabox_list_html(
+			array( 'zbs-test-box' => $this->make_box() ),
+			array( 'zbs-test-box' ),
+			'Main Column'
+		);
+
+		$this->assertStringNotContainsString( 'checked="checked"', $html );
+	}
+
+	/**
+	 * A metabox that cannot be hidden comes back checked and disabled.
+	 */
+	public function test_screen_options_list_disables_a_metabox_that_cannot_be_hidden() {
+		$html = jpcrm_screen_options_metabox_list_html(
+			array(
+				'zbs-test-box' => $this->make_box( array( 'capabilities' => array( 'can_hide' => false ) ) ),
+			),
+			array(),
+			'Main Column'
+		);
+
+		$this->assertStringContainsString( 'disabled="disabled"', $html );
+	}
+}


### PR DESCRIPTION
Closes #38.

Metaboxes have had a `$metaboxIcon` property since 2.98.7, but `initMetabox()` threw it away and concatenated the markup into the title instead, under a comment calling itself a lazy hackaround. That made `$box['title']` an HTML string, so every place printing a title had to pick between escaping it and showing the user a literal `<i class="heartbeat icon"></i>`, or not escaping it and keeping the title as an HTML sink. #37 fixed one of those places. This stops the two values being merged at all.

The icon now rides along as its own key on the box. `zeroBSCRM_add_meta_box()` takes an `$icon = ''` parameter, appended last so existing callers keep working, forwarded through the array-of-screens recursion and restored in the `sorted` branch. Each render point asks `jpcrm_metabox_icon_html()` for the markup and goes back to `esc_html()` on the title.

That picks up two places #37 didn't. The tab head was escaping the raw markup, and would have shown tags to the first icon-bearing box that could become a tab. Screen options was echoing `$mbTitle` and `$mbID` with no escaping at all.

The two screen options blocks doing that were near-identical copies, so rather than fix the same thing twice they are now one `jpcrm_screen_options_metabox_list_html()`. That is more than the issue asked for. Happy to split it out if you would rather review it on its own. One thing rode along with the extraction that is worth naming rather than leaving to be rediscovered in a bisect: the hidden-box check went from a loose `in_array()` to a strict one against a cast string. Metabox IDs are all non-numeric strings and `$hidden` arrives as `FILTER_UNSAFE_RAW`, so nothing changes in practice, but it is a third change inside a commit advertised as de-duplication.

## Nothing renders differently

For the two metaboxes that actually set an icon, the output is byte-identical to trunk. I checked rather than assumed: `wp_kses()` on the old concatenated title and the new icon-plus-escaped-title produce the same string, so the header and the drag overlay can't have regressed. The change is structural.

## Extensions

What I wasn't sure about when I filed the issue was whether an extension subclasses `zeroBS__Metabox` and hardcodes `<i>` markup into `metaboxTitle` directly. That renders fine after #37 and would start showing literal tags after this. I've checked now, across the extensions repo, the mail campaigns plugin and the customer app: nothing sets `metaboxIcon`, nothing calls `zeroBSCRM_add_meta_box()` directly, and the four places that set `metaboxTitle` all set a bare `__()` string.

The one path worth naming, because a search for those three terms misses it, is `zeroBS__Metabox_ContactCustomFiles`. It takes a `$titleOverride` in its constructor and has no callers inside this plugin at all, so an extension is the only thing that would instantiate it and whatever it passes becomes the title. Nothing instantiates it either.

An extension passing markup in a title to `zeroBSCRM_add_meta_box()` would lose it, but that was already true before #37, and #37 hasn't shipped in a release.

## Tests

Adds `tests/php/metabox/`, which the plugin had none of. Twenty tests covering the icon helper, registration through all four paths, each of the four render points, and the two shipped metaboxes that set an icon. Full suite is 71, all passing.

The `sorted` re-registration path gets its own test. That branch reads the title, callback and the rest back off the existing registration, and now the icon with them; its only caller is commented out, so a regression there would have sat unnoticed until someone uncommented it. Deleting the icon line from that branch fails the test, which is the only reason to trust it.

## Testing instructions

Open a contact (View, not Edit) and check the Activity box in the side column still has its heartbeat icon, then start dragging metaboxes around and check the blocker overlay that covers Activity shows the icon too, rather than a literal `<i class="heartbeat icon"></i>`. Same on a company.

Then open Screen Options on the contact edit screen and confirm the box list still reads normally. No icon to look for there: that list is only built for `zbs-add-edit-contact-edit`, and both icon-bearing boxes register against `zbs-view-contact` and `zerobs_view_company`, so no icon has ever reached it. The icon branch in that helper is correct but unreachable today. What the step actually exercises is the new escaping, and specifically `esc_attr()` on the `id` and `for` attributes, since `ZeroBSCRM.admin.metabox.manager.js:44` does `id.substr(7)` to recover the metabox ID and toggle it. Metabox IDs contain nothing `esc_attr()` touches, so it should be inert, but that is the one thing worth clicking.

I haven't run this in a browser myself. The byte-identical check above is why I think it's safe, but a second pair of eyes on it would be welcome.
