### PR TITLE
Release Jetpack CRM 6.8.3

### DIFF
--- a/ZeroBSCRM.php
+++ b/ZeroBSCRM.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack CRM
  * Plugin URI: https://jetpackcrm.com
  * Description: Jetpack CRM is the simplest CRM for WordPress. Self host your own Customer Relationship Manager using WP.
- * Version: 6.8.2
+ * Version: 6.8.3
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Plugin version. Single source of truth, bumped by the release tooling
 // (release.config.json "versionConstant"). ZeroBSCRM::VERSION reads from this,
 // so this define must be set before the autoloader loads that class below.
-define( 'JPCRM_VERSION', '6.8.2' );
+define( 'JPCRM_VERSION', '6.8.3' );
 
 // Enabling THIS will start LOGGING PERFORMANCE TESTS
 // NOTE: This will do for EVERY page load, so just add temporarily else adds rolling DRAIN on sys

--- a/includes/ZeroBSCRM.AJAX.php
+++ b/includes/ZeroBSCRM.AJAX.php
@@ -258,7 +258,7 @@ function zeroBSCRM_AJAX_getCustInvs() {
 	$ret = array();
 
 	// } If perms?
-	if ( zeroBSCRM_permsCustomers() ) {
+	if ( zeroBSCRM_permsViewInvoices() ) {
 
 		// } Retrieve ID
 		$cID = -1;
@@ -1961,6 +1961,33 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 		exit( 0 );
 }
 
+/**
+ * Rejects a list view sort direction that isn't ASC or DESC.
+ *
+ * The sort direction is interpolated into an ORDER BY clause further down, so anything
+ * that isn't one of the two recognised directions is rejected rather than passed along.
+ *
+ * The check is case insensitive but the value itself is returned unchanged: it is passed
+ * on to extensions via zerobs_ajax_list_view_{listtype}, which have always seen the
+ * lowercase form the list view sends. buildSort() uppercases it for the query itself.
+ *
+ * @param string|false $sort_order Sort direction as supplied in the request.
+ *
+ * @return string|false The unmodified sort direction, or false if it was empty or unrecognised.
+ */
+function jpcrm_sanitize_list_view_sort_order( $sort_order ) {
+
+	if ( empty( $sort_order ) || ! is_string( $sort_order ) ) {
+		return false;
+	}
+
+	if ( ! in_array( strtoupper( $sort_order ), array( 'ASC', 'DESC' ), true ) ) {
+		return false;
+	}
+
+	return $sort_order;
+}
+
 	// } Retrieves data sets for list views, with passed params :)
 	add_action( 'wp_ajax_retrieveListViewData', 'zeroBSCRM_AJAX_listViewRetrieveData' );
 function zeroBSCRM_AJAX_listViewRetrieveData() {
@@ -2000,6 +2027,10 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 	if ( ! empty( $listViewParams['sort'] ) && ! preg_match( '/^[a-zA-Z_][a-zA-Z0-9_-]*$/', $listViewParams['sort'] ) ) {
 		$listViewParams['sort'] = false;
 	}
+
+	// Security: validate sort direction for the same reason. The DAL normalises this as well,
+	// but this is the request-facing entry point, so reject anything that isn't ASC or DESC here.
+	$listViewParams['sortorder'] = jpcrm_sanitize_list_view_sort_order( $listViewParams['sortorder'] );
 
 	// deal with arrayed items
 
@@ -5623,7 +5654,7 @@ function zeroBSCRM_AJAX_getInvoice() {
 	check_ajax_referer( 'zbscrmjs-ajax-nonce', 'sec' );
 
 	// check perms
-	if ( ! zeroBSCRM_permsIsZBSUser() ) {
+	if ( ! zeroBSCRM_permsViewInvoices() ) {
 		wp_send_json_error( null, 500, JSON_UNESCAPED_SLASHES );
 	}
 

--- a/includes/ZeroBSCRM.CustomerFilters.php
+++ b/includes/ZeroBSCRM.CustomerFilters.php
@@ -86,7 +86,7 @@ function zeroBSCRM_CompanyTypeList( $jsCallbackFuncStr = '', $inputDefaultValue 
 		// } Wrap
 		$ret .= '<div class="zbstypeaheadwrap ' . $extraClasses . '">';
 
-		$ret .= '<input class="zbstypeaheadco" type="text" value="' . $inputDefaultValue . '" placeholder="' . __( jpcrm_label_company() . ' name...', 'zero-bs-crm' ) . '" data-zbsopencallback="' . $jsCallbackFuncStr . '" data-zbschangecallback="' . $jsChangeCallbackFuncStr . '" autocomplete="' . esc_attr( jpcrm_disable_browser_autocomplete() ) . '" data-autokey="cotypelist">'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase,WordPress.WP.I18n.NonSingularStringLiteralText
+		$ret .= '<input class="zbstypeaheadco" type="text" value="' . esc_attr( $inputDefaultValue ) . '" placeholder="' . esc_attr( __( jpcrm_label_company() . ' name...', 'zero-bs-crm' ) ) . '" data-zbsopencallback="' . $jsCallbackFuncStr . '" data-zbschangecallback="' . $jsChangeCallbackFuncStr . '" autocomplete="' . esc_attr( jpcrm_disable_browser_autocomplete() ) . '" data-autokey="cotypelist">'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase,WordPress.WP.I18n.NonSingularStringLiteralText
 
 		// } close wrap
 		$ret .= '</div>';

--- a/includes/ZeroBSCRM.DAL3.php
+++ b/includes/ZeroBSCRM.DAL3.php
@@ -8569,7 +8569,7 @@ class zbsDAL {
 
 			$sortOrder = strtoupper( $sortOrder );
 
-			if ( ! in_array( $sortOrder, array( 'DESC', 'ASC' ) ) ) {
+			if ( ! in_array( $sortOrder, array( 'DESC', 'ASC' ), true ) ) {
 				$sortOrder = 'DESC';
 			}
 			return ' ORDER BY ' . $sortByField . ' ' . $sortOrder;
@@ -8579,10 +8579,16 @@ class zbsDAL {
 			$orderByStr = '';
 			foreach ( $sortByField as $field => $order ) {
 
+				$order = strtoupper( $order );
+
+				if ( ! in_array( $order, array( 'DESC', 'ASC' ), true ) ) {
+					$order = 'DESC';
+				}
+
 				if ( ! empty( $orderByStr ) ) {
 					$orderByStr .= ', ';
 				}
-				$orderByStr .= $field . ' ' . strtoupper( $order );
+				$orderByStr .= $field . ' ' . $order;
 
 			}
 

--- a/includes/ZeroBSCRM.Permissions.php
+++ b/includes/ZeroBSCRM.Permissions.php
@@ -613,7 +613,7 @@ function zeroBSCRM_permsObjType( $obj_type_id = -1 ) { // phpcs:ignore WordPress
  * Anything with no listener is denied, as is anything asked for by someone with
  * no CRM access at all.
  *
- * @since $$next-version$$
+ * @since 6.8.3
  *
  * @param string $list_type List view type, as used by zeroBSCRM_list (e.g. 'customer', 'event').
  *
@@ -670,7 +670,7 @@ function jpcrm_perms_view_list_type( $list_type ) {
 	 * Note that an extension type only reaches this filter as `true` for a user
 	 * who already has CRM backend access.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.8.3
 	 *
 	 * @param bool   $allowed   Whether the user may view this list type.
 	 * @param string $list_type The list view type requested.
@@ -847,7 +847,7 @@ function zeroBSCRM_perms_tasks() {
  * This mirrors the capability used by the Task Scheduler and Task List admin
  * pages, which is separate from the task edit capability.
  *
- * @since $$next-version$$
+ * @since 6.8.3
  *
  * @return bool
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@automattic/jetpack-crm",
-	"version": "6.8.2",
+	"version": "6.8.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@automattic/jetpack-crm",
-			"version": "6.8.2",
+			"version": "6.8.3",
 			"license": "GPL-2.0",
 			"devDependencies": {
 				"@automattic/babel-plugin-preserve-i18n": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-crm",
-	"version": "6.8.2",
+	"version": "6.8.3",
 	"description": "The CRM for WordPress",
 	"repository": {
 		"type": "git",

--- a/phpunit.11.xml.dist
+++ b/phpunit.11.xml.dist
@@ -28,11 +28,17 @@
 		<testsuite name="entities">
 			<directory suffix="Test.php">tests/php/entities</directory>
 		</testsuite>
+		<testsuite name="dal">
+			<directory suffix="Test.php">tests/php/dal</directory>
+		</testsuite>
 		<testsuite name="pdf">
 			<directory suffix="Test.php">tests/php/pdf</directory>
 		</testsuite>
 		<testsuite name="permissions">
 			<directory suffix="Test.php">tests/php/permissions</directory>
+		</testsuite>
+		<testsuite name="ajax">
+			<directory suffix="Test.php">tests/php/ajax</directory>
 		</testsuite>
 	</testsuites>
 

--- a/phpunit.9.xml.dist
+++ b/phpunit.9.xml.dist
@@ -19,11 +19,17 @@
 		<testsuite name="entities">
 			<directory suffix="Test.php">tests/php/entities</directory>
 		</testsuite>
+		<testsuite name="dal">
+			<directory suffix="Test.php">tests/php/dal</directory>
+		</testsuite>
 		<testsuite name="pdf">
 			<directory suffix="Test.php">tests/php/pdf</directory>
 		</testsuite>
 		<testsuite name="permissions">
 			<directory suffix="Test.php">tests/php/permissions</directory>
+		</testsuite>
+		<testsuite name="ajax">
+			<directory suffix="Test.php">tests/php/ajax</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, kallehauge, cleacos, diegogarciarodrigues, bradshawtm, wpkaren, robertf4, woodyhayday, mikemayhem3030
 Tags: CRM, Woocommerce CRM, Client Portal, Marketing Automation, Lead Generation
 Tested up to: 7.0
-Stable tag: 6.8.2
+Stable tag: 6.8.3
 Requires at least: 6.0
 Requires PHP: 7.4
 License: GPLv2

--- a/tests/php/ajax/Invoice_Capability_Test.php
+++ b/tests/php/ajax/Invoice_Capability_Test.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Tests the capability gates on the invoice AJAX read handlers.
+ *
+ * These deliberately do not extend WP_Ajax_UnitTestCase. That case is in the
+ * `ajax` group, which the WordPress bootstrap excludes unless you pass
+ * --group ajax, so tests written that way are silently skipped and look green
+ * while never running.
+ *
+ * @package Automattic\JetpackCRM
+ */
+
+namespace Automattic\Jetpack\CRM\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use WPDieException;
+
+/**
+ * Capability gates on zbs_get_invoice_data and getinvs.
+ */
+class Invoice_Capability_Test extends JPCRM_Base_Integration_TestCase {
+
+	/**
+	 * Roles that hold admin_zerobs_view_invoices and should reach invoice data.
+	 *
+	 * zerobs_mailmgr is included on purpose. It reads as a role that should be
+	 * refused, but it is granted the view capability
+	 * deliberately and the KB documents mail managers as having read-only
+	 * access to invoices and transactions.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function allowed_roles(): array {
+		return array(
+			'administrator'  => array( 'administrator' ),
+			'CRM admin'      => array( 'zerobs_admin' ),
+			'invoice mgr'    => array( 'zerobs_invoicemgr' ),
+			'customer mgr'   => array( 'zerobs_customermgr' ),
+			'mail mgr'       => array( 'zerobs_mailmgr' ),
+		);
+	}
+
+	/**
+	 * Roles with CRM access but no invoice capability at all.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function refused_roles(): array {
+		return array(
+			'quote mgr'       => array( 'zerobs_quotemgr' ),
+			'transaction mgr' => array( 'zerobs_transactionmgr' ),
+		);
+	}
+
+	/**
+	 * Capture what a handler passes to wp_send_json* without exiting.
+	 *
+	 * Status codes are not checked here. wp_send_json() only sets one when
+	 * headers_sent() is false, which it never is under PHPUnit, so the response
+	 * body is the only thing actually observable.
+	 *
+	 * @param callable $handler The AJAX handler to invoke.
+	 * @return mixed The decoded response body.
+	 */
+	private function capture_json_response( callable $handler ) {
+		// wp_send_json() calls a bare die() unless wp_doing_ajax() is true, which
+		// would take the whole PHP process with it rather than throwing.
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$die_handler = static function () {
+			return static function () {
+				throw new WPDieException( 'sent' );
+			};
+		};
+		add_filter( 'wp_die_ajax_handler', $die_handler );
+		add_filter( 'wp_die_handler', $die_handler );
+
+		ob_start();
+		try {
+			$handler();
+		} catch ( WPDieException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Expected: wp_send_json always terminates.
+		}
+		$output = ob_get_clean();
+
+		remove_filter( 'wp_die_ajax_handler', $die_handler );
+		remove_filter( 'wp_die_handler', $die_handler );
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+
+		return json_decode( $output, true );
+	}
+
+	/**
+	 * Set the current user to a fresh user with the given role, and supply a
+	 * valid nonce so the handler gets past check_ajax_referer.
+	 *
+	 * @param string $role  The role to create the user with.
+	 * @param string $nonce The nonce action the handler checks.
+	 * @return void
+	 */
+	private function acting_as( string $role, string $nonce ): void {
+		$user_id = self::factory()->user->create( array( 'role' => $role ) );
+		wp_set_current_user( $user_id );
+
+		$_REQUEST['sec'] = wp_create_nonce( $nonce );
+		$_POST['sec']    = $_REQUEST['sec'];
+	}
+
+	/**
+	 * Build an invoice attached to a contact.
+	 *
+	 * @return array{contact: int, invoice: int}
+	 */
+	private function seed_invoice(): array {
+		$contact_id = $this->add_contact();
+		$invoice_id = $this->add_invoice(
+			array(
+				'contact' => array( $contact_id ),
+				'status'  => 'Unpaid',
+			)
+		);
+
+		return array(
+			'contact' => $contact_id,
+			'invoice' => $invoice_id,
+		);
+	}
+
+	/**
+	 * zbs_get_invoice_data used to gate on zeroBSCRM_permsIsZBSUser(), which is
+	 * true for any CRM user at all.
+	 *
+	 * @param string $role The role under test.
+	 */
+	#[DataProvider( 'refused_roles' )]
+	public function test_get_invoice_data_refuses_roles_without_the_view_capability( string $role ) {
+		$seed = $this->seed_invoice();
+		$this->acting_as( $role, 'zbscrmjs-ajax-nonce' );
+		$_POST['invid'] = $seed['invoice'];
+
+		$response = $this->capture_json_response( 'zeroBSCRM_AJAX_getInvoice' );
+
+		$this->assertIsArray( $response, "$role should get a JSON error back" );
+		$this->assertArrayHasKey( 'success', $response, "$role should be refused invoice data" );
+		$this->assertFalse( $response['success'], "$role should be refused invoice data" );
+		$this->assertArrayNotHasKey( 'invoiceObj', $response, "$role must not receive invoice data" );
+	}
+
+	/**
+	 * The gate must not be so tight that documented read-only roles lose access.
+	 *
+	 * @param string $role The role under test.
+	 */
+	#[DataProvider( 'allowed_roles' )]
+	public function test_get_invoice_data_allows_roles_with_the_view_capability( string $role ) {
+		$seed = $this->seed_invoice();
+		$this->acting_as( $role, 'zbscrmjs-ajax-nonce' );
+		$_POST['invid'] = $seed['invoice'];
+
+		$response = $this->capture_json_response( 'zeroBSCRM_AJAX_getInvoice' );
+
+		$this->assertIsArray( $response, "$role should reach invoice data" );
+		$this->assertArrayHasKey( 'invoiceObj', $response, "$role should reach invoice data" );
+		$this->assertArrayNotHasKey( 'success', $response, "$role should not get an error response" );
+	}
+
+	/**
+	 * getinvs used to gate on zeroBSCRM_permsCustomers(), so contacts access was
+	 * enough to pull every invoice for a contact.
+	 *
+	 * @param string $role The role under test.
+	 */
+	#[DataProvider( 'refused_roles' )]
+	public function test_getinvs_refuses_roles_without_the_view_capability( string $role ) {
+		$seed = $this->seed_invoice();
+		$this->acting_as( $role, 'zbscrmjs-glob-ajax-nonce' );
+		$_POST['cid'] = $seed['contact'];
+
+		$response = $this->capture_json_response( 'zeroBSCRM_AJAX_getCustInvs' );
+
+		$this->assertSame( array(), $response, "$role should get no invoices back" );
+	}
+
+	/**
+	 * @param string $role The role under test.
+	 */
+	#[DataProvider( 'allowed_roles' )]
+	public function test_getinvs_allows_roles_with_the_view_capability( string $role ) {
+		$seed = $this->seed_invoice();
+		$this->acting_as( $role, 'zbscrmjs-glob-ajax-nonce' );
+		$_POST['cid'] = $seed['contact'];
+
+		$response = $this->capture_json_response( 'zeroBSCRM_AJAX_getCustInvs' );
+
+		$this->assertNotEmpty( $response, "$role should get the contact's invoices" );
+	}
+
+	/**
+	 * Guards the fix itself: contacts access alone must never be sufficient.
+	 * If someone reverts either handler to a contacts-based check, this fails.
+	 */
+	public function test_contacts_access_alone_is_not_enough_for_invoices() {
+		$user_id = self::factory()->user->create( array( 'role' => 'zerobs_quotemgr' ) );
+		wp_set_current_user( $user_id );
+
+		$this->assertTrue(
+			zeroBSCRM_permsCustomers(),
+			'quote manager is expected to have contacts access, otherwise this test proves nothing'
+		);
+		$this->assertFalse(
+			zeroBSCRM_permsViewInvoices(),
+			'quote manager must not have invoice view access'
+		);
+	}
+
+	/**
+	 * Clean up request superglobals between tests.
+	 */
+	public function tear_down(): void {
+		unset( $_POST['sec'], $_POST['invid'], $_POST['cid'], $_REQUEST['sec'] );
+		parent::tear_down();
+	}
+}

--- a/tests/php/dal/Sort_Order_Validation_Test.php
+++ b/tests/php/dal/Sort_Order_Validation_Test.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Automattic\Jetpack\CRM\Tests;
+
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Tests that buildSort() only ever emits a recognised sort direction.
+ *
+ * The array (multi-sort) branch did not check the direction against the two values it
+ * accepts, so an unrecognised one reached the ORDER BY clause unchanged.
+ */
+class Sort_Order_Validation_Test extends JPCRM_Base_TestCase {
+
+	/**
+	 * @testdox Test that an unrecognised sort direction is normalised in the array branch.
+	 */
+	#[TestDox( 'Test that an unrecognised sort direction is normalised in the array branch.' )]
+	public function test_array_branch_normalises_unrecognised_sort_direction() {
+		global $zbs;
+
+		$sort = $zbs->DAL->buildSort( array( 'external_source_uids' => 'ASC,(SELECT SLEEP(3))' ) );
+
+		$this->assertSame( ' ORDER BY external_source_uids DESC', $sort );
+	}
+
+	/**
+	 * @testdox Test that a valid sort direction is kept in the array branch.
+	 */
+	#[TestDox( 'Test that a valid sort direction is kept in the array branch.' )]
+	public function test_array_branch_keeps_valid_sort_direction() {
+		global $zbs;
+
+		$sort = $zbs->DAL->buildSort( array( 'zbsc_fname' => 'ASC' ) );
+
+		$this->assertSame( ' ORDER BY zbsc_fname ASC', $sort );
+	}
+
+	/**
+	 * @testdox Test that multi-sort keeps each direction and capitalises it.
+	 */
+	#[TestDox( 'Test that multi-sort keeps each direction and capitalises it.' )]
+	public function test_array_branch_keeps_each_direction_in_multi_sort() {
+		global $zbs;
+
+		$sort = $zbs->DAL->buildSort(
+			array(
+				'zbsc_fname' => 'ASC',
+				'zbsc_lname' => 'desc',
+			)
+		);
+
+		$this->assertSame( ' ORDER BY zbsc_fname ASC, zbsc_lname DESC', $sort );
+	}
+
+	/**
+	 * @testdox Test that the list view rejects an unrecognised sort direction.
+	 */
+	#[TestDox( 'Test that the list view rejects an unrecognised sort direction.' )]
+	public function test_list_view_rejects_unrecognised_sort_order() {
+		$this->assertFalse( jpcrm_sanitize_list_view_sort_order( 'ASC,(SELECT SLEEP(3))' ) );
+	}
+
+	/**
+	 * @testdox Test that the list view accepts a valid sort direction in any case, unaltered.
+	 */
+	#[TestDox( 'Test that the list view accepts a valid sort direction in any case, unaltered.' )]
+	public function test_list_view_accepts_valid_sort_order() {
+		$this->assertSame( 'asc', jpcrm_sanitize_list_view_sort_order( 'asc' ) );
+		$this->assertSame( 'DESC', jpcrm_sanitize_list_view_sort_order( 'DESC' ) );
+	}
+
+	/**
+	 * @testdox Test that the list view treats an absent sort direction as unset.
+	 */
+	#[TestDox( 'Test that the list view treats an absent sort direction as unset.' )]
+	public function test_list_view_rejects_empty_sort_order() {
+		$this->assertFalse( jpcrm_sanitize_list_view_sort_order( '' ) );
+		$this->assertFalse( jpcrm_sanitize_list_view_sort_order( false ) );
+	}
+}


### PR DESCRIPTION


> [!IMPORTANT]
> Merging this PR will build and publish the new version automatically as a GitHub release, then deploy the new version on the WordPress.org plugin repository.
>

## Jetpack CRM 6.8.3

> [!NOTE]
> These release notes between the two `---` lines will be the final changelog entry for the release. Edit them freely here before merging.
>

### Release Notes

---
* Fix Activity panel header icon rendering (#37)
* Don't let self-reported details replace contact fields already filled in (#30)
* Check that the current user may view a list view type before returning its data. Task and form list views were not checked before.
* Add a `jpcrm_perms_view_list_type` filter, so a site can grant or deny access to any list view. Use it if custom code shows a task or form list view behind a different capability.
* Bump @wordpress/theme to 1.0.0 and migrate WPDS token names (#14)
* CRM: Align admin footer with the unified Jetpack footer (#8)
* Only accept a recognised sort direction on list views.
* Require the invoice viewing capability to read invoice data over AJAX.
* Escape the prefilled company name in the company field.
---

### Release

> [!NOTE]
> Click 'Ready for Review', ping the team, review the PR and merge. Upon merging, automation will:
> - Write the release notes above to the changelog
> - Create and tag a new GitHub release
> - Deploy the release to WordPress.org

