### PR TITLE
Exempt release PRs from the next-version lint

### DIFF
--- a/.github/workflows/lint-next-version.yml
+++ b/.github/workflows/lint-next-version.yml
@@ -5,6 +5,15 @@ on:
 
 jobs:
   next-version-tags:
+    # Release PRs are exempt. prepare-release.mjs rewrites every $$next-version$$
+    # to the real version as part of cutting the branch, so the substituted @since
+    # lines fail this check on every release. Feature PRs, where a hand-written
+    # version is a genuine mistake, are what it exists for.
+    #
+    # This has to be a head_ref test rather than a `branches-ignore:` filter,
+    # because for pull_request those filters match the base branch, and a release
+    # PR targets trunk like any other.
+    if: ${{ ! startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
The 6.8.3 release PR failed this check on three @since tags it had not written.
prepare-release.mjs runs replaceNextVersionPlaceholder() when it cuts the branch,
so every $$next-version$$ becomes the real version, and the check then sees added
lines carrying a hard-coded one. It fires on every release. The script's
"next-version-ok" escape hatch would technically work, but only if the marker sat
in the source beside every @since $$next-version$$ from the start, and it also
silences the near-miss check on those lines, so it costs more than it saves.

The check is for feature PRs, where a hand-written version is a real mistake.

It has to be a head_ref test. `branches-ignore:` looked like the obvious fix and is
wrong: for pull_request those filters match the base branch, and a release PR
targets trunk like everything else, so it would skip nothing.

This is shared tooling, so the same change goes to crowdsignal-forms,
crowdsignal-plugin and wp-super-cache. WP-Job-Manager does not have this workflow.
None of the four had hit this yet: the workflow landed in the other three on
2026-07-14 and their last releases all predate it, so 6.8.3 is the first release
PR in the family to run the check.
