### PR TITLE
Show Revenue Chart when transactions net to zero or below

### DIFF
--- a/admin/dashboard/main.page.php
+++ b/admin/dashboard/main.page.php
@@ -198,7 +198,7 @@ function jpcrm_render_dashboard_page() {
 
 				<div class="jpcrm-listview-table-container">
 					<?php
-					if ( is_array( $transaction_totals_array ) && array_sum( $transaction_totals_array ) > 0 ) {
+					if ( ! empty( $recent_transactions ) ) {
 						?>
 						<div>
 							<canvas id="bar-chart" height="400"></canvas>

--- a/admin/dashboard/main.page.php
+++ b/admin/dashboard/main.page.php
@@ -83,7 +83,6 @@ function jpcrm_render_dashboard_page() {
 	$labels = array_reverse( $labels );
 
 	$transaction_totals_by_month = array();
-	$transaction_totals_array    = array();
 
 	// fill with zeros if months aren't present
 	for ( $i = 11; $i > 0; $i-- ) {
@@ -97,16 +96,9 @@ function jpcrm_render_dashboard_page() {
 	);
 
 	$recent_transactions = $zbs->DAL->transactions->getTransactionTotalByMonth( $args ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-	foreach ( $recent_transactions as $k => $v ) {
-		$transaction_totals_array[ $k ]       = $v['total'];
+	foreach ( $recent_transactions as $v ) {
 		$dkey                                 = $v['month'] . $v['year'];
 		$transaction_totals_by_month[ $dkey ] = $v['total'];
-	}
-
-	$i = 0;
-	foreach ( $transaction_totals_by_month as $k => $v ) {
-		$transaction_totals_array[ $i ] = $v;
-		++$i;
 	}
 
 	$chartdata = array_values( $transaction_totals_by_month );


### PR DESCRIPTION
## Problem

The dashboard Revenue Chart renders only when the last 12 months of transactions sum to more than zero. A site whose net is zero or below gets the empty state instead, with a message saying it has no valid transactions — while those transactions exist and count toward every other total.

Affects sites that record expenses as negative transactions.

## Fix

`admin/dashboard/main.page.php`

    - if ( is_array( $transaction_totals_array ) && array_sum( $transaction_totals_array ) > 0 ) {
    + if ( ! empty( $recent_transactions ) ) {

Tests whether the query returned rows rather than what they sum to. `$recent_transactions` is already in scope from line 99.

## Repro

Two `Succeeded` transactions dated today, `+100` and `-200`. Before: empty state. After: chart with an August bar at −100.

---
Before
<img width="1275" height="647" alt="Screenshot 2026-08-20 at 8 37 09 in the evening" src="https://github.com/user-attachments/assets/9903d3cf-bb22-4725-acaa-80b4ed58dacb" />

After

<img width="1325" height="709" alt="Screenshot 2026-08-20 at 8 37 58 in the evening" src="https://github.com/user-attachments/assets/96196b0a-cc23-4749-b357-08eb28e945ed" />

How alternating months would look like

<img width="1189" height="507" alt="Screenshot 2026-08-20 at 8 43 54 in the evening" src="https://github.com/user-attachments/assets/68c1cad2-cd97-43ee-aa60-493a8241314b" />


## Notes

- No JS change needed. Chart.js renders negatives natively and `beginAtZero` is already set.
- Negative bars draw green: the dash JS applies one flat colour and `zbs_root` exposes no red token. Left out deliberately, it's a palette decision.
- A site whose transactions sum to exactly zero now gets a flat chart instead of the "Add a transaction" CTA. Intentional, but a behaviour change.

Fixes JETCRM-1451
