### PR TITLE
Update tested up to version to WordPress 7.1

### DIFF
--- a/includes/ZeroBSCRM.Core.php
+++ b/includes/ZeroBSCRM.Core.php
@@ -48,7 +48,7 @@ final class ZeroBSCRM {
 	 *
 	 * @var string
 	 */
-	public $wp_tested = '7.0';
+	public $wp_tested = '7.1';
 
 	/**
 	 * WordPress update API version.

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack CRM - Clients, Leads, Invoices, Billing, Email Marketing, & Automation ===
 Contributors: automattic, kallehauge, cleacos, diegogarciarodrigues, bradshawtm, wpkaren, robertf4, woodyhayday, mikemayhem3030
 Tags: CRM, Woocommerce CRM, Client Portal, Marketing Automation, Lead Generation
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 6.8.3
 Requires at least: 6.0
 Requires PHP: 7.4


### PR DESCRIPTION
#### Description

Bumps the tested-against WordPress version from 7.0 to 7.1. WordPress 7.1 is the current release, per the wp.org version-check API.

Two places hold it. `Tested up to:` in `readme.txt` is the wp.org listing. `$wp_tested` in `ZeroBSCRM.Core.php` is what the extension update code falls back to when the licensing API sends no `tested` value of its own, so without it the extension version-details panel keeps reporting 7.0.

No version bump, and `Stable tag` stays at 6.8.3.

#### Testing instructions

Nothing to run. Confirm the diff is the two version strings and nothing else.
