### PR TITLE
Add a manually-dispatched workflow to update the WP.org readme without a release

### DIFF
--- a/.github/workflows/update-wporg-readme.yml
+++ b/.github/workflows/update-wporg-readme.yml
@@ -3,6 +3,14 @@ name: Update WordPress.org Readme/Assets
 # Push readme.txt and .wordpress-org assets to WordPress.org without cutting a
 # release — e.g. to bump "Tested up to" after a new WordPress version. Updates
 # SVN trunk, the assets directory, and the readme in the current stable tag.
+#
+# Caveat: this publishes trunk's readme.txt exactly as it stands, including
+# into the stable tag users see. If trunk's readme carries anything meant for
+# the *next* release (new changelog entries, a bumped stable tag), don't
+# dispatch this — ship the release instead. Before dispatching, check that
+# the only differences are ones meant to go live now:
+#
+#   curl -s https://plugins.svn.wordpress.org/zero-bs-crm/tags/<stable>/readme.txt | diff - readme.txt
 on:
   workflow_dispatch:
 

--- a/.github/workflows/update-wporg-readme.yml
+++ b/.github/workflows/update-wporg-readme.yml
@@ -1,0 +1,26 @@
+name: Update WordPress.org Readme/Assets
+
+# Push readme.txt and .wordpress-org assets to WordPress.org without cutting a
+# release — e.g. to bump "Tested up to" after a new WordPress version. Updates
+# SVN trunk, the assets directory, and the readme in the current stable tag.
+on:
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    name: Push readme and assets to WordPress.org
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install SVN
+        run: sudo apt-get update && sudo apt-get install -y subversion
+      - name: Update readme/assets on WordPress.org
+        uses: 10up/action-wordpress-plugin-asset-update@2480306f6f693672726d08b5917ea114cb2825f7 # 2.2.0
+        env:
+          SVN_PASSWORD: ${{ secrets.WORDPRESSORG_SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.WORDPRESSORG_SVN_USERNAME }}
+          SLUG: zero-bs-crm
+          # SVN trunk holds the *built* plugin while git trunk is source, so
+          # everything except readme.txt and assets always differs. Only copy
+          # readme.txt and .wordpress-org/; ignore all other differences.
+          IGNORE_OTHER_FILES: true


### PR DESCRIPTION
## Summary

Adds `.github/workflows/update-wporg-readme.yml`, a `workflow_dispatch`-only workflow that pushes `readme.txt` and the `.wordpress-org` assets to the WordPress.org SVN — trunk, assets, and the readme inside the current stable tag — using the existing `WORDPRESSORG_SVN_*` secrets. It uses [10up/action-wordpress-plugin-asset-update](https://github.com/10up/action-wordpress-plugin-asset-update) (pinned to 2.2.0 by SHA), the companion to the deploy action the release workflow already uses.

## Why

`Tested up to` was bumped to 7.1 on trunk in #47, but the value users see comes from the stable tag's `readme.txt` on WordPress.org, which still says 7.0. This lets us publish that (and future readme/asset changes) without cutting a release.

`IGNORE_OTHER_FILES: true` is required here: SVN trunk holds the built plugin while git trunk is source, so every file except the readme and assets always differs.

## Usage

After merging: **Actions → Update WordPress.org Readme/Assets → Run workflow** (or `gh workflow run update-wporg-readme.yml`).

Verified before opening this PR that git trunk's `readme.txt` differs from the shipped `tags/6.8.3/readme.txt` only in the `Tested up to` line, so the sync will change nothing else.

No milestone: CI-only change, nothing ships to users, so it's left out of the release changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)