### PR TITLE
Fix the revenue chart's 12-month window start and current-month zero-prefill

### DIFF
--- a/admin/dashboard/main.page.php
+++ b/admin/dashboard/main.page.php
@@ -71,7 +71,7 @@ function jpcrm_render_dashboard_page() {
 
 	$funnel_data = array_reverse( $funnel_data );
 
-	/* Transactions - Revenue Chart data gen */
+	// Transactions - Revenue Chart data gen.
 	// One pass over the 12-month window, oldest month first: each month-start
 	// timestamp drives the chart label, the zero-prefill key, and (for the oldest
 	// month) the query window start, so the three cannot drift apart. They used
@@ -89,7 +89,8 @@ function jpcrm_render_dashboard_page() {
 		if ( ! $window_start ) {
 			$window_start = $month_start;
 		}
-		$labels[]                                                    = gmdate( 'M y', $month_start );
+		$labels[] = gmdate( 'M y', $month_start );
+
 		$transaction_totals_by_month[ gmdate( 'nY', $month_start ) ] = 0;
 	}
 

--- a/admin/dashboard/main.page.php
+++ b/admin/dashboard/main.page.php
@@ -74,8 +74,6 @@ function jpcrm_render_dashboard_page() {
 	/* Transactions - Revenue Chart data gen */
 	$labels = array();
 
-	$labels[0] = gmdate( 'F Y' );
-
 	for ( $i = 0; $i < 12; $i++ ) {
 		$labels[ $i ] = gmdate( 'M y', mktime( 0, 0, 0, gmdate( 'm' ) - $i, 1, (int) gmdate( 'Y' ) ) );
 	}
@@ -85,13 +83,17 @@ function jpcrm_render_dashboard_page() {
 	$transaction_totals_by_month = array();
 
 	// fill with zeros if months aren't present
-	for ( $i = 11; $i > 0; $i-- ) {
+	for ( $i = 11; $i >= 0; $i-- ) {
 		$key                                 = gmdate( 'nY', mktime( 0, 0, 0, gmdate( 'm' ) - $i, 1, (int) gmdate( 'Y' ) ) );
 		$transaction_totals_by_month[ $key ] = 0;
 	}
 
 	$args = array(
-		'paidAfter'  => strtotime( 'first day of ' . gmdate( 'F Y', strtotime( '11 month ago' ) ) ),
+		// Derive the window start with the same mktime() arithmetic as the labels
+		// and zero-prefill above: strtotime( '11 month ago' ) overflows on
+		// month-end days (e.g. May 31 -> "June 31" -> July 1), which excluded the
+		// oldest labeled month from the query.
+		'paidAfter'  => mktime( 0, 0, 0, (int) gmdate( 'm' ) - 11, 1, (int) gmdate( 'Y' ) ),
 		'paidBefore' => time(),
 	);
 

--- a/admin/dashboard/main.page.php
+++ b/admin/dashboard/main.page.php
@@ -72,28 +72,29 @@ function jpcrm_render_dashboard_page() {
 	$funnel_data = array_reverse( $funnel_data );
 
 	/* Transactions - Revenue Chart data gen */
-	$labels = array();
-
-	for ( $i = 0; $i < 12; $i++ ) {
-		$labels[ $i ] = gmdate( 'M y', mktime( 0, 0, 0, gmdate( 'm' ) - $i, 1, (int) gmdate( 'Y' ) ) );
-	}
-
-	$labels = array_reverse( $labels );
-
+	// One pass over the 12-month window, oldest month first: each month-start
+	// timestamp drives the chart label, the zero-prefill key, and (for the oldest
+	// month) the query window start, so the three cannot drift apart. They used
+	// to: the window start came from strtotime( '11 month ago' ), which overflows
+	// on month-end days (e.g. May 31 -> "June 31" -> July 1) and silently
+	// excluded the oldest labeled month from the query.
+	$labels                      = array();
 	$transaction_totals_by_month = array();
+	$window_start                = 0;
 
-	// fill with zeros if months aren't present
+	$this_month = (int) gmdate( 'm' );
+	$this_year  = (int) gmdate( 'Y' );
 	for ( $i = 11; $i >= 0; $i-- ) {
-		$key                                 = gmdate( 'nY', mktime( 0, 0, 0, gmdate( 'm' ) - $i, 1, (int) gmdate( 'Y' ) ) );
-		$transaction_totals_by_month[ $key ] = 0;
+		$month_start = mktime( 0, 0, 0, $this_month - $i, 1, $this_year );
+		if ( ! $window_start ) {
+			$window_start = $month_start;
+		}
+		$labels[]                                                    = gmdate( 'M y', $month_start );
+		$transaction_totals_by_month[ gmdate( 'nY', $month_start ) ] = 0;
 	}
 
 	$args = array(
-		// Derive the window start with the same mktime() arithmetic as the labels
-		// and zero-prefill above: strtotime( '11 month ago' ) overflows on
-		// month-end days (e.g. May 31 -> "June 31" -> July 1), which excluded the
-		// oldest labeled month from the query.
-		'paidAfter'  => mktime( 0, 0, 0, (int) gmdate( 'm' ) - 11, 1, (int) gmdate( 'Y' ) ),
+		'paidAfter'  => $window_start,
 		'paidBefore' => time(),
 	);
 


### PR DESCRIPTION
## Summary

Fixes items 1, 2 and 6 of #50 — the three verified, decision-free defects in the dashboard revenue chart's data generation (`admin/dashboard/main.page.php`). Items 3–5 of #50 (paid-date vs transaction-date semantics, boundary `>` vs `>=`, MySQL-session-tz bucketing) stay parked there: each needs a product call on which date the chart should key on.

- **Window start**: `strtotime( '11 month ago' )` overflows on month-end days (on May 31 it resolves to "June 31" → July 1), so the query excluded the oldest labeled month — the oldest bar silently showed 0, and a site whose only transactions fall in that month got the "No valid transactions" empty state. The bound is now derived with the same `mktime()` arithmetic the labels and zero-prefill use, so it always matches the oldest label. Verified with `php -r`: old expression on May 31 → `2025-07-01`; new → `2025-06-01`; today's bound `2025-09-01` = oldest label `Sep 25`.
- **Zero-prefill**: `for ( $i = 11; $i > 0; $i-- )` skipped `$i = 0`, so a current month with no transactions produced 11 data values against 12 labels and the current-month label rendered with no bar. Now `$i >= 0`. (Key format `gmdate( 'nY' )` matches the `MONTH() . YEAR()` keys from the data loop, and the current month stays last, matching the reversed labels.)
- **Dead code**: `$labels[0] = gmdate( 'F Y' );` was immediately overwritten by the loop on the next line.

## Testing

`make lint-staged` clean; `make test` green (110 tests, 369 assertions).

## Note

Touches the same block as the dead-code cleanup requested on #45, so whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)