### PR TITLE
Run the PHPUnit suite in CI on PRs and on trunk

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,90 @@
+name: PHPUnit tests
+
+# The test half of #41. Same provisioning shape as the Jetpack monorepo's CI:
+# a wordpress-develop checkout plus a database service, with the plugin's own
+# `composer phpunit` doing the running. Local development keeps using wp-env
+# (`make test`); drift between the two is prevented by sharing everything that
+# matters — the bootstrap (tests/php/bootstrap.php), the composer script, and
+# the WORDPRESS_DEVELOP_DIR contract the bootstrap resolves.
+#
+# One leg for now: current stable WordPress on PHP 8.5. Widening to the
+# supported floor (WP 6.0, PHP 7.4) is blocked on a decision about
+# composer.lock, which is resolved on a modern host and refuses to install on
+# PHP < 8.4 — an older leg needs per-version dependency resolution, the way
+# the monorepo (which commits no lock) gets it.
+
+on:
+  pull_request:
+    branches:
+      - trunk
+  # Trunk is deliberately not PR-gated, so also test what actually lands.
+  push:
+    branches:
+      - trunk
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    services:
+      database:
+        image: mariadb:lts
+        env:
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: wordpress_tests
+        ports:
+          - 3306:3306
+        # healthcheck.sh ships in the mariadb image; --innodb_initialized
+        # waits for the server to be writable, not just accepting connections.
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # The version wp-env runs locally ("core": null in .wp-env.json is
+      # "current stable"), so CI tests the same WordPress developers do.
+      # wordpress-develop tags every release, x.y and x.y.z alike.
+      - name: Resolve current stable WordPress
+        id: wp
+        run: |
+          version=$(curl -sf https://api.wordpress.org/core/version-check/1.7/ | jq -r '.offers[0].version')
+          test -n "$version" && test "$version" != "null"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: WordPress/wordpress-develop
+          ref: ${{ steps.wp.outputs.version }}
+          path: wordpress-develop
+
+      # The WP test bootstrap finds wp-tests-config.php at the
+      # wordpress-develop root on its own; no WP_TESTS_CONFIG_FILE_PATH needed.
+      - name: Create wp-tests-config.php
+        run: |
+          sed -e 's/youremptytestdbnamehere/wordpress_tests/' \
+              -e 's/yourusernamehere/root/' \
+              -e 's/yourpasswordhere/root/' \
+              -e 's/localhost/127.0.0.1/' \
+              wordpress-develop/wp-tests-config-sample.php > wordpress-develop/wp-tests-config.php
+
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          # composer.lock is resolved on a modern host and locks packages
+          # requiring php >= 8.4.1; 8.5 is what development runs on. See the
+          # note at the top about widening this.
+          php-version: '8.5'
+          tools: composer
+          coverage: none
+
+      - name: Install PHP dependencies
+        run: composer install --no-ansi --no-interaction --prefer-dist --no-progress
+
+      # `composer phpunit` picks phpunit.<major>.xml.dist to match the
+      # installed PHPUnit, same as it does locally.
+      - name: Run PHPUnit
+        env:
+          WORDPRESS_DEVELOP_DIR: ${{ github.workspace }}/wordpress-develop
+        run: composer phpunit


### PR DESCRIPTION
The test half of #41; the lint half is #53. Together they close it, modulo the matrix question below.

**What**

A `PHPUnit tests` workflow that runs the plugin's own `composer phpunit` against a wordpress-develop checkout and a MariaDB service, on every PR against trunk and on every push to trunk (trunk is deliberately not PR-gated, so what lands gets tested too).

**Why this shape**

This is the pattern Jetpack CI uses for plugin PHPUnit runs: GitHub-hosted runner, database service container, wordpress-develop checkout, `WORDPRESS_DEVELOP_DIR` pointing at it. wp-env stays the local workflow (`make test`); CI and local don't need identical provisioning as long as they share the parts where drift would matter, and they do — the same `tests/php/bootstrap.php` (which already resolves `WORDPRESS_DEVELOP_DIR` as its first-choice location), the same `composer phpunit` script (which picks `phpunit.<major>.xml.dist` to match the installed PHPUnit), and the same WordPress test library.

**Choices made**

- **WordPress version:** current stable, resolved at run time from the wordpress.org version-check API and checked out by tag. That's what wp-env runs locally (`"core": null` = current stable), so CI tests the same WordPress developers do. A pinned ref would go stale silently; trunk would break spuriously.
- **PHP 8.5, one leg.** composer.lock is resolved on a modern host and locks packages requiring `php >= 8.4.1`, so `composer install` refuses anything older (#53 hit the same wall at 8.3). Widening to the supported floor — WP 6.0, PHP 7.4, which the `phpunit.9.xml.dist` config already anticipates — needs a decision about per-version dependency resolution first (the monorepo gets this by committing no lock). Left open under #41.
- **MariaDB (`mariadb:lts`)**, matching Jetpack CI, with the image's own `healthcheck.sh --connect --innodb_initialized` as the readiness gate.

**Testing**

Rehearsed the exact CI recipe locally before writing the YAML: fresh wordpress-develop checkout at tag 7.1, MariaDB in a container, `wp-tests-config.php` generated from the sample with the same `sed` lines, then `WORDPRESS_DEVELOP_DIR=… composer phpunit`.

Result: `OK (110 tests, 369 assertions)` in 27s, PHPUnit 12.5.31 picking `phpunit.12.xml.dist` via the symlink.

This PR's own check is the end-to-end run in Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvvHfGbJ9Qd4pqibZyh2g7
