### PR TITLE
Release Jetpack CRM 6.8.4

### DIFF
--- a/ZeroBSCRM.php
+++ b/ZeroBSCRM.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack CRM
  * Plugin URI: https://jetpackcrm.com
  * Description: Jetpack CRM is the simplest CRM for WordPress. Self host your own Customer Relationship Manager using WP.
- * Version: 6.8.3
+ * Version: 6.8.4
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Plugin version. Single source of truth, bumped by the release tooling
 // (release.config.json "versionConstant"). ZeroBSCRM::VERSION reads from this,
 // so this define must be set before the autoloader loads that class below.
-define( 'JPCRM_VERSION', '6.8.3' );
+define( 'JPCRM_VERSION', '6.8.4' );
 
 // Enabling THIS will start LOGGING PERFORMANCE TESTS
 // NOTE: This will do for EVERY page load, so just add temporarily else adds rolling DRAIN on sys

--- a/admin/dashboard/dashboard.ajax.php
+++ b/admin/dashboard/dashboard.ajax.php
@@ -8,6 +8,14 @@ function jetpackcrm_dash_refresh() {
 
 	check_ajax_referer( 'zbs_dash_count', 'security' );  // nonce it up...
 
+	// The nonce alone does not gate this: it only proves the request came from a
+	// page that printed the nonce. Require the same capability the dashboard page
+	// itself registers with ('zbs_dash'), so the CRM aggregates this returns are
+	// not served to a logged-in user who has no CRM access.
+	if ( ! current_user_can( 'zbs_dash' ) ) {
+		wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
+	}
+
 	// note for WH - looking at the DAL, we can probably extract these into DAL3 helpers?
 	global $zbs, $wpdb, $ZBSCRM_t; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 

--- a/includes/ZeroBSCRM.AJAX.php
+++ b/includes/ZeroBSCRM.AJAX.php
@@ -5534,34 +5534,6 @@ function zeroBSCRM_AJAX_sendStatement() {
 		wp_send_json( $r, 200, JSON_UNESCAPED_SLASHES );
 }
 
-add_action( 'wp_ajax_zbs_invoice_mark_paid', 'zbs_invoice_mark_paid' );
-function zbs_invoice_mark_paid() {
-
-	// } get if poss
-	$zbs_invID = -1;
-	if ( isset( $_POST['id'] ) && ! empty( $_POST['id'] ) ) {
-		$zbs_invID = (int) sanitize_text_field( $_POST['id'] );  // accepts the post ID
-	}
-
-	// } Check id + perms + em
-	if ( $zbs_invID < 1 || ! zeroBSCRM_permsInvoices() ) {
-
-		die( 0 );
-
-	}
-
-	// } Continue
-
-	// once the invoice is sent it will mark it as unpaid (automatically)
-	$zbs_inv_meta           = get_post_meta( $zbs_invID, 'zbs_customer_invoice_meta', true ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-	$zbs_inv_meta['status'] = 'Paid';
-	update_post_meta( $zbs_invID, 'zbs_customer_invoice_meta', $zbs_inv_meta ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-
-	// all OK ....
-	$r = array( 'message' => 'All done OK' );
-	wp_send_json( $r, 200, JSON_UNESCAPED_SLASHES );
-}
-
 // } and send test so they can test before actually sending the invoice
 add_action( 'wp_ajax_zbs_invoice_send_test_invoice', 'zbs_invoice_send_test_invoice' );
 function zbs_invoice_send_test_invoice() {

--- a/includes/ZeroBSCRM.DAL3.Export.php
+++ b/includes/ZeroBSCRM.DAL3.Export.php
@@ -21,6 +21,27 @@ if ( ! defined( 'ZEROBSCRM_PATH' ) ) {
 	/ Breaking Checks
 	====================================================== */
 
+/**
+ * Neutralise CSV formula injection in a single exported cell.
+ *
+ * A spreadsheet treats a cell beginning with =, +, -, @, tab or carriage return
+ * as a formula, so a contact whose (attacker-supplied) field starts with one of
+ * those can run when a CRM user opens the export in Excel, LibreOffice or
+ * Sheets. Prefixing a single quote makes the spreadsheet render it as text.
+ *
+ * Done at the export boundary rather than on input, so stored records already
+ * carrying such values are covered too. Non-string cells are returned unchanged.
+ *
+ * @param mixed $value The cell value.
+ * @return mixed The value, prefixed with a single quote if it would be read as a formula.
+ */
+function jpcrm_csv_escape_formula( $value ) {
+	if ( is_string( $value ) && $value !== '' && strpos( "=+-@\t\r", $value[0] ) !== false ) {
+		return "'" . $value;
+	}
+	return $value;
+}
+
 // temp/mvp solution. Some fields need different labels for export!
 function zeroBSCRM_export_fieldReplacements() {
 
@@ -289,7 +310,7 @@ function jpcrm_export_process_file_export() {
 				}
 				}
 				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- Just ignore until someone fixes all of these, otherwise we wind up having to rewrite half the function.
-				fputcsv( $output, $columnHeaders, ',', '"', '' );
+				fputcsv( $output, array_map( 'jpcrm_csv_escape_formula', $columnHeaders ), ',', '"', '' );
 
 				// actual export lines
 
@@ -440,7 +461,7 @@ function jpcrm_export_process_file_export() {
 
 							// output row
 							// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- Just ignore until someone fixes all of these, otherwise we wind up having to rewrite half the function.
-							fputcsv( $output, $objRow, ',', '"', '' );
+							fputcsv( $output, array_map( 'jpcrm_csv_escape_formula', $objRow ), ',', '"', '' );
 
 					} // / foreach obj
 				}

--- a/includes/ZeroBSCRM.FormatHelpers.php
+++ b/includes/ZeroBSCRM.FormatHelpers.php
@@ -1503,7 +1503,9 @@ function zeroBSCRM_html_editField( $dataArr = array(), $fieldKey = false, $field
 
 			   <?php 
 
-			   if ($fieldKey == 'mobtel'){
+			   // The Twilio extension's send handler requires this same capability
+			   // (jetpack-crm-extensions#884), so without it the button only ever fails.
+			   if ($fieldKey == 'mobtel' && zeroBSCRM_permsSendEmailContacts()){
 
 								$sms_class = 'send-sms-none';
 								$sms_class = apply_filters('zbs_twilio_sms', $sms_class); 
@@ -1986,7 +1988,9 @@ if (!empty($fieldKey) && is_array($fieldVal)){
 
 										<?php 
 
-											if ($fieldKey == 'mobtel'){
+											// The Twilio extension's send handler requires this same capability
+											// (jetpack-crm-extensions#884), so without it the button only ever fails.
+											if ($fieldKey == 'mobtel' && zeroBSCRM_permsSendEmailContacts()){
 
 											$sms_class = 'send-sms-none';
 											$sms_class = apply_filters('zbs_twilio_sms', $sms_class); 

--- a/includes/ZeroBSCRM.Forms.php
+++ b/includes/ZeroBSCRM.Forms.php
@@ -251,7 +251,7 @@ function zeroBSCRM_forms_getRecaptcha() {
 	$reCaptcha    = zeroBSCRM_getSetting( 'usegcaptcha' );
 	$reCaptchaKey = zeroBSCRM_getSetting( 'gcaptchasitekey' );
 	if ( $reCaptcha && ! empty( $reCaptchaKey ) ) {
-		return '<div class="zbscrmReCaptcha"><div class="g-recaptcha" data-sitekey="' . $reCaptchaKey . '"></div></div>';
+		return '<div class="zbscrmReCaptcha"><div class="g-recaptcha" data-sitekey="' . esc_attr( $reCaptchaKey ) . '"></div></div>'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	}
 
 	return '';

--- a/includes/ZeroBSCRM.Permissions.php
+++ b/includes/ZeroBSCRM.Permissions.php
@@ -1103,6 +1103,14 @@ function jpcrm_can_wp_user_view_object( $wp_user, $obj_id, $obj_type_id ) {
 		return false;
 	}
 
+	// Not logged in. wp_get_current_user() hands back a WP_User with ID 0 for an
+	// anonymous visitor, which is a truthy object, so this has to test the ID.
+	// It also has to run before the object retrieval below, which calls
+	// $wp_user->has_cap() and would fatal on a non-user.
+	if ( ! $wp_user || empty( $wp_user->ID ) ) {
+		return false;
+	}
+
 	global $zbs;
 
 	// retrieve object
@@ -1129,11 +1137,6 @@ function jpcrm_can_wp_user_view_object( $wp_user, $obj_id, $obj_type_id ) {
 
 	// no such object!
 	if ( ! $obj_data ) {
-		return false;
-	}
-
-	// not logged in
-	if ( ! $wp_user ) {
 		return false;
 	}
 
@@ -1201,6 +1204,35 @@ function jpcrm_can_access_portal_via_hash( $obj_type_id ) {
 	}
 	// access via hash is allowed
 	return true;
+}
+
+/**
+ * Whether an object is an unpublished draft that must not be reachable through
+ * its easy-access hash link.
+ *
+ * A quote's published state is derived from its template: zeroBS_getQuote()
+ * reports 'not yet published' unless the quote has a template ( > 0 ). Returning
+ * a quote to Draft clears that, so a draft is a quote with no template. Invoices
+ * carry an explicit 'Draft' status. Both should stop resolving through a
+ * previously issued hash link.
+ *
+ * @param int $obj_id       Object ID.
+ * @param int $obj_type_id  Object type ID.
+ *
+ * @return bool True if the object is a draft that should not be served by hash.
+ */
+function jpcrm_portal_hash_object_is_draft( $obj_id, $obj_type_id ) {
+
+	switch ( $obj_type_id ) {
+		case ZBS_TYPE_QUOTE:
+			$quote = zeroBS_getQuote( $obj_id );
+			return ! is_array( $quote ) || (int) ( $quote['template'] ?? -1 ) <= 0;
+		case ZBS_TYPE_INVOICE:
+			$invoice = zeroBS_getInvoice( $obj_id );
+			return is_array( $invoice ) && isset( $invoice['status'] ) && $invoice['status'] === 'Draft';
+	}
+
+	return false;
 }
 
 /**

--- a/js/ZeroBSCRM.admin.global.js
+++ b/js/ZeroBSCRM.admin.global.js
@@ -1471,8 +1471,12 @@ function zbscrm_JS_isEmail(email) {
  * @param email
  */
 function zbscrm_JS_validateEmail( email ) {
+	// The quoted-local-part alternative ("...")@domain is deliberately omitted:
+	// it let a contact name of the form "payload"@x.tld pass as an email and be
+	// laundered into the invoice/quote email modals. Real recipient addresses in
+	// this CRM do not use quoted local parts, so dropping it costs nothing here.
 	const re =
-		/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+		/^([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 	return re.test( email );
 }
 

--- a/js/ZeroBSCRM.admin.invoicebuilder.js
+++ b/js/ZeroBSCRM.admin.invoicebuilder.js
@@ -292,25 +292,28 @@ function zbscrm_JS_draw_invoice_actions_html( res ) {
  *
  */
 function zbscrmJS_retrieveCurrentBillToEmail() {
-	// email? (if assigned)
-	let potentialEmail = jQuery( '#zbs_inv_bill' ).val();
-	// if not set already, then get from this:
-	if ( typeof potentialEmail === 'undefined' || ! zbscrm_JS_validateEmail( potentialEmail ) ) {
-		// here we allow for prefilled data via zbsprefillcust _GET param (passed by php)
-		let billTo = window.zbs_invoice.invoiceObj.bill;
-		if (
-			! billTo &&
-			typeof window.zbsJS_prefillemail !== 'undefined' &&
-			typeof window.zbsJS_prefillid !== 'undefined'
-		) {
-			// prefill - contact/company email
-			billTo = window.zbsJS_prefillemail;
-		}
+	// Resolve the recipient from the invoice's billing email, never from the
+	// #zbs_inv_bill typeahead input. That input shows the contact/company NAME
+	// (invoiceObj.bill_name), which is attacker-controlled via the public lead
+	// form; reading it back as an email let a name like "x"@y.tld through the
+	// validator and into the email modal. The billing email is the only real
+	// address we hold for the recipient.
+	let potentialEmail = window.zbs_invoice.invoiceObj.bill;
 
-		potentialEmail = billTo;
+	// here we allow for prefilled data via zbsprefillcust _GET param (passed by php)
+	if (
+		! potentialEmail &&
+		typeof window.zbsJS_prefillemail !== 'undefined' &&
+		typeof window.zbsJS_prefillid !== 'undefined'
+	) {
+		// prefill - contact/company email
+		potentialEmail = window.zbsJS_prefillemail;
 	}
 
-	return potentialEmail;
+	// Return an empty string rather than a name when no email is known, so the
+	// zbscrm_JS_validateEmail() checks at the call sites fail closed and the
+	// Email Invoice button stays hidden.
+	return potentialEmail || '';
 }
 
 /**
@@ -2196,7 +2199,7 @@ function zbscrmJS_sendInvoiceModal() {
 			'</label>';
 		optsHTML +=
 			'<input type="email" id="zbs_invoice_email_modal_toemail" value="' +
-			invEmail +
+			jpcrm.esc_attr( invEmail ) +
 			'" placeholder="' +
 			jpcrm.esc_attr( zbscrm_JS_invoice_lang( 'toemailplaceholder' ) ) +
 			'" />';

--- a/js/ZeroBSCRM.admin.quotebuilder.js
+++ b/js/ZeroBSCRM.admin.quotebuilder.js
@@ -261,7 +261,7 @@ function jpcrm_quotes_send_email_modal() {
 			'</label>';
 		optsHTML +=
 			'<input type="email" id="jpcrm_quote_email_modal_toemail" value="' +
-			recipientEmail +
+			jpcrm.esc_attr( recipientEmail ) +
 			'" placeholder="' +
 			jpcrm.esc_attr( jpcrm_quotes_lang( 'toemailplaceholder' ) ) +
 			'" />';

--- a/js/ZeroBSCRM.public.leadform.js
+++ b/js/ZeroBSCRM.public.leadform.js
@@ -200,8 +200,12 @@ function zbscrm_JS_leadformcapture( zbs_form_id, zbs_ajaxurl, t ) {
  * @return {boolean} True if it matches the regex, otherwise false.
  */
 function zbscrm_JS_validateEmail( email ) {
+	// The quoted-local-part alternative ("...")@domain is deliberately omitted:
+	// it let a contact name of the form "payload"@x.tld pass as an email and be
+	// laundered into the invoice/quote email modals. Real recipient addresses in
+	// this CRM do not use quoted local parts, so dropping it costs nothing here.
 	const re =
-		/^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+		/^([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 	return re.test( email );
 }
 

--- a/modules/portal/class-client-portal-router.php
+++ b/modules/portal/class-client-portal-router.php
@@ -141,6 +141,15 @@ class Client_Portal_Router {
 			if ( ! $obj_id ) {
 				return false;
 			}
+
+			// A draft object must not resolve through its easy-access hash.
+			// Returning a quote to Draft is meant to un-share it; without this
+			// the hash link issued while it was published keeps working. The
+			// numeric-ID path below already refuses drafts via
+			// jpcrm_can_current_wp_user_view_object().
+			if ( jpcrm_portal_hash_object_is_draft( $obj_id, $obj_type_id ) ) {
+				return false;
+			}
 		} else {
 
 			// not a hash, so cast to int

--- a/modules/portal/endpoints/class-single-quote-endpoint.php
+++ b/modules/portal/endpoints/class-single-quote-endpoint.php
@@ -19,7 +19,7 @@ class Single_Quote_Endpoint extends Client_Portal_Endpoint {
 			$new_endpoint->hide_from_menu               = true;
 			$new_endpoint->template_name                = 'single-quote.php';
 			$new_endpoint->add_rewrite_endpoint         = true;
-			$new_endpoint->should_check_user_permission = $zbs->settings->get( 'easyaccesslinks' ) === '0';
+			$new_endpoint->should_check_user_permission = $zbs->settings->get( 'easyaccesslinks' ) === 0;
 			$new_endpoint->hide_from_settings_page      = true;
 
 			$endpoints[] = $new_endpoint;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@automattic/jetpack-crm",
-	"version": "6.8.3",
+	"version": "6.8.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@automattic/jetpack-crm",
-			"version": "6.8.3",
+			"version": "6.8.4",
 			"license": "GPL-2.0",
 			"devDependencies": {
 				"@automattic/babel-plugin-preserve-i18n": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-crm",
-	"version": "6.8.3",
+	"version": "6.8.4",
 	"description": "The CRM for WordPress",
 	"repository": {
 		"type": "git",

--- a/phpunit.11.xml.dist
+++ b/phpunit.11.xml.dist
@@ -34,6 +34,9 @@
 		<testsuite name="pdf">
 			<directory suffix="Test.php">tests/php/pdf</directory>
 		</testsuite>
+		<testsuite name="format-helpers">
+			<directory suffix="Test.php">tests/php/format-helpers</directory>
+		</testsuite>
 		<testsuite name="woo-sync">
 			<directory suffix="Test.php">tests/php/woo-sync</directory>
 		</testsuite>

--- a/phpunit.9.xml.dist
+++ b/phpunit.9.xml.dist
@@ -25,6 +25,9 @@
 		<testsuite name="pdf">
 			<directory suffix="Test.php">tests/php/pdf</directory>
 		</testsuite>
+		<testsuite name="format-helpers">
+			<directory suffix="Test.php">tests/php/format-helpers</directory>
+		</testsuite>
 		<testsuite name="woo-sync">
 			<directory suffix="Test.php">tests/php/woo-sync</directory>
 		</testsuite>

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, kallehauge, cleacos, diegogarciarodrigues, bradshawtm, wpkaren, robertf4, woodyhayday, mikemayhem3030
 Tags: CRM, Woocommerce CRM, Client Portal, Marketing Automation, Lead Generation
 Tested up to: 7.1
-Stable tag: 6.8.3
+Stable tag: 6.8.4
 Requires at least: 6.0
 Requires PHP: 7.4
 License: GPLv2

--- a/readme.txt
+++ b/readme.txt
@@ -362,6 +362,19 @@ We offer a full, no-hassle refund within 14 days. You can read more about that, 
 
 
 == Changelog ==
+### 6.8.4 - 2026-09-02
+* Allow assigning a transaction to a company invoice (#52)
+* Fix the revenue chart's 12-month window start and current-month zero-prefill (#51)
+* Show the Revenue Chart when transactions net to zero or below (#45)
+* Let a first Woo Sync import overwrite the contacts it created itself (#33)
+* Stop forms clearing contact details, and updates clearing the owner (#34)
+* Escape email addresses, the reCAPTCHA site key, and spreadsheet output.
+* Expire a quote's easy-access link when it returns to Draft.
+* Correct the permission check on the single-quote client portal endpoint.
+* Require the dashboard capability for the dashboard data endpoint.
+* Remove an unused invoice AJAX handler.
+* Show the SMS button only to roles permitted to send SMS.
+
 ### 6.8.3 - 2026-08-18
 * Fix Activity panel header icon rendering (#37)
 * Don't let self-reported details replace contact fields already filled in (#30)

--- a/tests/php/dal/CSV_Formula_Injection_Test.php
+++ b/tests/php/dal/CSV_Formula_Injection_Test.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Tests for CSV formula-injection escaping in exports.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\Tests;
+
+use PHPUnit\Framework\Attributes\TestDox;
+
+/**
+ * Tests that jpcrm_csv_escape_formula() neutralises CSV formula injection.
+ *
+ * A CRM export is user-controlled data (a contact's own fields, a public lead
+ * form submission), so a cell beginning with =, +, -, @, tab or carriage return
+ * would run as a formula when the export is opened in a spreadsheet. The helper
+ * prefixes a single quote so the cell renders as text; everything else is left
+ * exactly as it was.
+ */
+class CSV_Formula_Injection_Test extends JPCRM_Base_TestCase {
+
+	/**
+	 * @testdox A cell starting with a formula trigger is prefixed with a single quote.
+	 */
+	#[TestDox( 'A cell starting with a formula trigger is prefixed with a single quote.' )]
+	public function test_formula_triggers_are_escaped() {
+		$this->assertSame( "'=1+2", jpcrm_csv_escape_formula( '=1+2' ) );
+		$this->assertSame( "'+SUM(A1)", jpcrm_csv_escape_formula( '+SUM(A1)' ) );
+		$this->assertSame( "'-2+3", jpcrm_csv_escape_formula( '-2+3' ) );
+		$this->assertSame( "'@cmd", jpcrm_csv_escape_formula( '@cmd' ) );
+		$this->assertSame( "'\tx", jpcrm_csv_escape_formula( "\tx" ) );
+		$this->assertSame( "'\rx", jpcrm_csv_escape_formula( "\rx" ) );
+	}
+
+	/**
+	 * @testdox An ordinary cell is returned unchanged.
+	 */
+	#[TestDox( 'An ordinary cell is returned unchanged.' )]
+	public function test_ordinary_values_are_untouched() {
+		$this->assertSame( '19 Prospect Hill', jpcrm_csv_escape_formula( '19 Prospect Hill' ) );
+		$this->assertSame( 'alex@example.com', jpcrm_csv_escape_formula( 'alex@example.com' ) );
+		$this->assertSame( 'Doe, John', jpcrm_csv_escape_formula( 'Doe, John' ) );
+		$this->assertSame( '', jpcrm_csv_escape_formula( '' ) );
+	}
+
+	/**
+	 * @testdox A non-string cell is returned unchanged.
+	 */
+	#[TestDox( 'A non-string cell is returned unchanged.' )]
+	public function test_non_string_values_pass_through() {
+		$this->assertSame( 5, jpcrm_csv_escape_formula( 5 ) );
+		$this->assertSame( 0, jpcrm_csv_escape_formula( 0 ) );
+		$this->assertNull( jpcrm_csv_escape_formula( null ) );
+	}
+}

--- a/tests/php/format-helpers/SMS_Button_Test.php
+++ b/tests/php/format-helpers/SMS_Button_Test.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Tests for gating the SMS button on the send capability.
+ *
+ * @package automattic/jetpack-crm
+ */
+
+namespace Automattic\Jetpack\CRM\FormatHelpers\Tests;
+
+use Automattic\Jetpack\CRM\Tests\JPCRM_Base_TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use WP_User;
+
+/**
+ * The SMS button rendered next to a contact's mobile number is handled by the
+ * Twilio extension, whose send handler requires `admin_zerobs_sendemails_contacts`.
+ * The button itself must be gated on the same capability, otherwise CRM roles
+ * that can open a contact but not send get a button that always fails.
+ */
+class SMS_Button_Test extends JPCRM_Base_TestCase {
+
+	/**
+	 * The mobile number the field is rendered with.
+	 *
+	 * @var string
+	 */
+	private const MOBILE = '5551234567';
+
+	/**
+	 * The capability that gates sending.
+	 *
+	 * @var string
+	 */
+	private const SEND_CAP = 'admin_zerobs_sendemails_contacts';
+
+	/**
+	 * Field definition for a `mobtel` field, as passed by the edit views.
+	 *
+	 * @var array
+	 */
+	private const FIELD = array( 'tel', 'Mobile', 'Mobile number' );
+
+	/**
+	 * Render `mobtel` through one of the two edit views and return the markup.
+	 *
+	 * @param string $renderer Name of the function under test.
+	 * @param array  $data     The object data to render from.
+	 */
+	private function render( string $renderer, array $data = array( 'mobtel' => self::MOBILE ) ): string {
+		ob_start();
+		$renderer( $data, 'mobtel', self::FIELD );
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Create a user with the given role.
+	 *
+	 * @param string $role A role name, or '' for a user with no role.
+	 */
+	private function create_user( string $role ): WP_User {
+		return get_userdata( self::factory()->user->create( array( 'role' => $role ) ) );
+	}
+
+	/**
+	 * Create a user with the given role and log in as them.
+	 *
+	 * @param string $role A role name, or '' for a user with no role.
+	 */
+	private function log_in_as( string $role ): int {
+		return $this->log_in( $this->create_user( $role ) );
+	}
+
+	/**
+	 * Log in as an existing user. Capabilities are read once when the current
+	 * user is set, so any per-user capability change has to happen before this.
+	 *
+	 * @param WP_User $user The user to log in as.
+	 */
+	private function log_in( WP_User $user ): int {
+		wp_set_current_user( $user->ID );
+
+		return $user->ID;
+	}
+
+	/**
+	 * Assert a role grants the capabilities this test assumes, so a role
+	 * definition that drifts from the source fails loudly here rather than
+	 * quietly turning a test into a tautology.
+	 *
+	 * @param int  $user_id  The user to check.
+	 * @param bool $can_send Whether the user is expected to hold the send capability.
+	 */
+	private function assert_send_capability( int $user_id, bool $can_send ): void {
+		$this->assertSame(
+			$can_send,
+			user_can( $user_id, self::SEND_CAP ),
+			'Role does not hold the capabilities this test assumes; check zeroBSCRM_addUserRoles().'
+		);
+	}
+
+	/**
+	 * The two core functions that render the button.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function render_sites(): array {
+		return array(
+			'contact edit view' => 'zeroBSCRM_html_editField',
+			'invoice edit view' => 'zeroBSCRM_html_editField_for_invoices',
+		);
+	}
+
+	/**
+	 * Pair every render site with every role, so both sites are covered for
+	 * every role without a test method per combination.
+	 *
+	 * @param array<string, string> $roles Role names keyed by a readable label.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	private static function every_site_for( array $roles ): array {
+		$cases = array();
+
+		foreach ( self::render_sites() as $site_label => $renderer ) {
+			foreach ( $roles as $role_label => $role ) {
+				$cases[ "{$site_label}, {$role_label}" ] = array( $renderer, $role );
+			}
+		}
+
+		return $cases;
+	}
+
+	/**
+	 * Roles that can reach a contact record but cannot send SMS, plus users
+	 * with no CRM role at all.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public static function sites_and_roles_without_send_capability(): array {
+		return self::every_site_for(
+			array(
+				'quote manager'       => 'zerobs_quotemgr',
+				'invoice manager'     => 'zerobs_invoicemgr',
+				'transaction manager' => 'zerobs_transactionmgr',
+				'CRM customer'        => 'zerobs_customer',
+				'WP subscriber'       => 'subscriber',
+				'no role'             => '',
+			)
+		);
+	}
+
+	/**
+	 * Roles that hold the send capability and must keep the button.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public static function sites_and_roles_with_send_capability(): array {
+		return self::every_site_for(
+			array(
+				'WP administrator' => 'administrator',
+				'CRM admin'        => 'zerobs_admin',
+				'contact manager'  => 'zerobs_customermgr',
+				'mail manager'     => 'zerobs_mailmgr',
+			)
+		);
+	}
+
+	/**
+	 * Roles without the capability get no button, at either render site.
+	 *
+	 * @dataProvider sites_and_roles_without_send_capability
+	 *
+	 * @param string $renderer The function under test.
+	 * @param string $role     A role name.
+	 */
+	#[DataProvider( 'sites_and_roles_without_send_capability' )]
+	public function test_hides_sms_button_without_send_capability( string $renderer, string $role ): void {
+		$this->assert_send_capability( $this->log_in_as( $role ), false );
+
+		$this->assertStringNotContainsString( 'data-smsnum', $this->render( $renderer ) );
+	}
+
+	/**
+	 * Roles with the capability keep the button, at either render site.
+	 *
+	 * @dataProvider sites_and_roles_with_send_capability
+	 *
+	 * @param string $renderer The function under test.
+	 * @param string $role     A role name.
+	 */
+	#[DataProvider( 'sites_and_roles_with_send_capability' )]
+	public function test_shows_sms_button_with_send_capability( string $renderer, string $role ): void {
+		$this->assert_send_capability( $this->log_in_as( $role ), true );
+
+		$this->assertStringContainsString( 'data-smsnum="' . self::MOBILE . '"', $this->render( $renderer ) );
+	}
+
+	/**
+	 * Capabilities live in the `wp_user_roles` option, so an old site or a role
+	 * editor can leave a role holding something its source definition does not.
+	 * The gate must follow the capability the user actually has, not the role name.
+	 */
+	public function test_follows_granted_capability_rather_than_role_name(): void {
+		$user = $this->create_user( 'zerobs_quotemgr' );
+		$user->add_cap( self::SEND_CAP );
+		$this->log_in( $user );
+
+		$this->assertStringContainsString( 'data-smsnum', $this->render( 'zeroBSCRM_html_editField' ) );
+	}
+
+	/**
+	 * The mirror case: a role that should hold the capability but has had it
+	 * taken away loses the button.
+	 */
+	public function test_follows_revoked_capability_rather_than_role_name(): void {
+		$user = $this->create_user( 'zerobs_customermgr' );
+		$user->add_cap( self::SEND_CAP, false );
+		$this->log_in( $user );
+
+		$this->assertStringNotContainsString( 'data-smsnum', $this->render( 'zeroBSCRM_html_editField' ) );
+	}
+
+	/**
+	 * The mobile number itself stays visible either way; only the button goes.
+	 */
+	public function test_mobile_number_still_rendered_without_send_capability(): void {
+		$this->log_in_as( 'zerobs_quotemgr' );
+
+		$this->assertStringContainsString( 'value="' . self::MOBILE . '"', $this->render( 'zeroBSCRM_html_editField' ) );
+	}
+
+	/**
+	 * A user who can send but has no number on the contact gets no button.
+	 */
+	public function test_no_button_when_contact_has_no_mobile_number(): void {
+		$this->log_in_as( 'zerobs_admin' );
+
+		$this->assertStringNotContainsString( 'data-smsnum', $this->render( 'zeroBSCRM_html_editField', array() ) );
+	}
+}


### PR DESCRIPTION


> [!IMPORTANT]
> Merging this PR will build and publish the new version automatically as a GitHub release, then deploy the new version on the WordPress.org plugin repository.
>

## Jetpack CRM 6.8.4

> [!NOTE]
> These release notes between the two `---` lines will be the final changelog entry for the release. Edit them freely here before merging.
>

### Release Notes

---
* Allow assigning a transaction to a company invoice (#52)
* Fix the revenue chart's 12-month window start and current-month zero-prefill (#51)
* Show Revenue Chart when transactions net to zero or below (#45)
* Make the invoice capability tests prove more than they did (#44)
* Stop forms clearing contact details, and updates clearing the owner (#34)
* Let a first Woo Sync import overwrite the contacts it created itself (#33)
---

### Release

> [!NOTE]
> Click 'Ready for Review', ping the team, review the PR and merge. Upon merging, automation will:
> - Write the release notes above to the changelog
> - Create and tag a new GitHub release
> - Deploy the release to WordPress.org
